### PR TITLE
Modified parser and encoder blocks for PTY Locale selection

### DIFF
--- a/grc/rds_encoder.xml
+++ b/grc/rds_encoder.xml
@@ -4,7 +4,21 @@
 	<key>gr_rds_encoder</key>
 	<category>RDS</category>
 	<import>import rds</import>
-	<make>rds.encoder()</make>
+	<make>rds.encoder($pty_locale)</make>
+	<param>
+		<name>PTY Locale</name>
+		<key>pty_locale</key>
+		<value>0</value>
+		<type>int</type>
+		<option>
+			<name>Europe</name>
+			<key>0</key>
+		</option>
+		<option>
+			<name>North America</name>
+			<key>1</key>
+		</option>
+	</param>
 	<sink>
 		<name>rds in</name>
 		<type>message</type>

--- a/grc/rds_parser.xml
+++ b/grc/rds_parser.xml
@@ -4,7 +4,7 @@
 	<key>gr_rds_parser</key>
 	<category>RDS</category>
 	<import>import rds</import>
-	<make>rds.parser($log, $debug)</make>
+	<make>rds.parser($log, $debug, $pty_locale)</make>
 	<callback>reset();$reset;</callback>
 	<param>
 		<name>Log</name>
@@ -32,6 +32,20 @@
 		<option>
 			<name>Disable</name>
 			<key>False</key>
+		</option>
+	</param>
+	<param>
+		<name>PTY Locale</name>
+		<key>pty_locale</key>
+		<value>0</value>
+		<type>int</type>
+		<option>
+			<name>Europe</name>
+			<key>0</key>
+		</option>
+		<option>
+			<name>North America</name>
+			<key>1</key>
 		</option>
 	</param>
 	<param>

--- a/include/rds/encoder.h
+++ b/include/rds/encoder.h
@@ -27,7 +27,7 @@ class RDS_API encoder : virtual public gr::sync_block
 {
 public:
 	typedef boost::shared_ptr<encoder> sptr;
-	static sptr make();
+	static sptr make(unsigned char pty_locale);
 };
 
 }

--- a/include/rds/parser.h
+++ b/include/rds/parser.h
@@ -27,7 +27,7 @@ class RDS_API parser : virtual public gr::block
 {
 public:
 	typedef boost::shared_ptr<parser> sptr;
-	static sptr make(bool log, bool debug);
+	static sptr make(bool log, bool debug, unsigned char pty_locale);
 
 	virtual void reset() = 0;
 };

--- a/lib/constants.h
+++ b/lib/constants.h
@@ -27,10 +27,8 @@ static const unsigned int offset_word[5]={252,408,360,436,848};
 static const unsigned int syndrome[5]={383,14,303,663,748};
 static const char * const offset_name[]={"A","B","C","D","C'"};
 
-/* page 77, Annex F in the standard */
-static const unsigned int PTY_EUROPE = 0;
-static const unsigned int PTY_NORTH_AMERICA = 1;
-static       unsigned int pty_locale = PTY_EUROPE;
+/* Annex F of RBDS Standard Table F.1 (North America) and
+ * Table F.2 (Europe) */
 const std::string pty_table[32][2]={
 	{"Undefined",             "Undefined"},
 	{"News",                  "News"},

--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -29,10 +29,12 @@
 
 using namespace gr::rds;
 
-encoder_impl::encoder_impl ()
+encoder_impl::encoder_impl (unsigned char pty_locale)
 	: gr::sync_block ("gr_rds_encoder",
 			gr::io_signature::make (0, 0, 0),
-			gr::io_signature::make (1, 1, sizeof(unsigned char))) {
+			gr::io_signature::make (1, 1, sizeof(unsigned char))), 
+	pty_locale(pty_locale)
+	{
 
 	message_port_register_in(pmt::mp("rds in"));
 	set_msg_handler(pmt::mp("rds in"), boost::bind(&encoder_impl::rds_in, this, _1));
@@ -495,7 +497,7 @@ int encoder_impl::work (int noutput_items,
 }
 
 encoder::sptr
-encoder::make () {
-	return gnuradio::get_initial_sptr(new encoder_impl());
+encoder::make (unsigned char pty_locale) {
+	return gnuradio::get_initial_sptr(new encoder_impl(pty_locale));
 }
 

--- a/lib/encoder_impl.h
+++ b/lib/encoder_impl.h
@@ -26,7 +26,7 @@ namespace rds {
 class encoder_impl : public encoder
 {
 public:
-	encoder_impl();
+	encoder_impl(unsigned char pty_locale);
 
 private:
 	~encoder_impl();
@@ -39,6 +39,7 @@ private:
 	unsigned int  checkword[4];
 	unsigned int  block[4];
 	unsigned char **buffer;
+	unsigned char pty_locale;
 
 	// FIXME make this a struct (or a class)
 	unsigned char PTY;

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -27,16 +27,17 @@
 using namespace gr::rds;
 
 parser::sptr
-parser::make(bool log, bool debug) {
-  return gnuradio::get_initial_sptr(new parser_impl(log, debug));
+parser::make(bool log, bool debug, unsigned char pty_locale) {
+  return gnuradio::get_initial_sptr(new parser_impl(log, debug, pty_locale));
 }
 
-parser_impl::parser_impl(bool log, bool debug)
+parser_impl::parser_impl(bool log, bool debug, unsigned char pty_locale)
 	: gr::block ("gr_rds_parser",
 			gr::io_signature::make (0, 0, 0),
 			gr::io_signature::make (0, 0, 0)),
 	log(log),
-	debug(debug)
+	debug(debug),
+	pty_locale(pty_locale)
 {
 	message_port_register_in(pmt::mp("in"));
 	set_msg_handler(pmt::mp("in"), boost::bind(&parser_impl::parse, this, _1));

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -26,7 +26,7 @@ namespace rds {
 class parser_impl : public parser
 {
 public:
-	parser_impl(bool log, bool debug);
+	parser_impl(bool log, bool debug, unsigned char pty_locale);
 
 private:
 	~parser_impl();
@@ -71,6 +71,7 @@ private:
 	bool           static_pty;
 	bool           debug;
 	bool           log;
+	unsigned char  pty_locale;
 	gr::thread::mutex d_mutex;
 };
 


### PR DESCRIPTION
Decided that the hack modification to hard-code the PTY Locale setting I added was a little too much of a hack. Modified the `parser` and `encoder` blocks to have a `PTY Locale` argument selecting to either `Europe` (default to not change any existing functionality) and `North America`. Also, modified the comment in `constants.h` identifying specifically which tables of the appendix contain the specific data sets. Images of the updated blocks in `grc` are attached.
![encoder_block](https://cloud.githubusercontent.com/assets/1534397/12381101/18d57272-bd51-11e5-9097-b10d0f019b4e.png)
![encoder_block_settings](https://cloud.githubusercontent.com/assets/1534397/12381103/18d6807c-bd51-11e5-9ff1-482edf4a8347.png)
![parser_block](https://cloud.githubusercontent.com/assets/1534397/12381102/18d5b566-bd51-11e5-83b9-e491b88df7a6.png)
![parser_block_settings](https://cloud.githubusercontent.com/assets/1534397/12381100/18d48556-bd51-11e5-8756-6830ac6c9457.png)



