### PR TITLE
Updating UHD Source to use 'gain' var

### DIFF
--- a/apps/rds_rx.grc
+++ b/apps/rds_rx.grc
@@ -3653,7 +3653,7 @@
     </param>
     <param>
       <key>gain0</key>
-      <value>0</value>
+      <value>gain</value>
     </param>
     <param>
       <key>ant10</key>


### PR DESCRIPTION
Didn't mean to have extra lines removed on previous commit. This one only modifies RF Gain filed under UHD block. 