### PR TITLE
minor windows fixes for gr-rds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ include(GrVersion) #setup version info
 if(NOT WIN32)
     #http://gcc.gnu.org/wiki/Visibility
     add_definitions(-fvisibility=hidden)
+else()
+    #enables std::min and std::max
+    add_definitions(-DNOMINMAX)
 endif()
 
 ########################################################################

--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -402,7 +402,7 @@ void encoder_impl::prepare_group2(const bool AB) {
 void encoder_impl::prepare_group1a(void) {
 	std::cout << "preparing group 1" << std::endl;
 	//infoword[1] = infoword[1] | (1 << 4); // TMC in 8A
-	infoword[2] = (0b10000000 << 8) | 0xE0;
+	infoword[2] = (0x80 << 8) | 0xE0;
 	infoword[3] = 0; // time
 }
 


### PR DESCRIPTION
* define -DNOMINMAX for std::min/max()
* replace 0b10000000 with 0x80 to compile