### PR TITLE
Use PDUs for communication from decoder to parser

### DIFF
--- a/lib/decoder_impl.h
+++ b/lib/decoder_impl.h
@@ -46,6 +46,7 @@ private:
 	unsigned int   blocks_counter;
 	unsigned int   group_good_blocks_counter;
 	unsigned int   group[4];
+	unsigned char  offset_chars[4];  // [ABCcDEx] (x=error)
 	bool           debug;
 	bool           log;
 	bool           presync;

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -33,7 +33,7 @@ private:
 
 	void reset();
 	void send_message(long, std::string);
-	void parse(pmt::pmt_t msg);
+	void parse(pmt::pmt_t pdu);
 	double decode_af(unsigned int);
 	void decode_optional_content(int, unsigned long int *);
 


### PR DESCRIPTION
Convert decoder and parser to use PDUs instead of raw messages, making
them compatible with other gnuradio PDU processing blocks.

Signed-off-by: Jonathan Brucker <jonathan.brucke@gmail.com>