### PR TITLE
Change tmc_events array to C strings

### DIFF
--- a/lib/decoder_impl.cc
+++ b/lib/decoder_impl.cc
@@ -139,7 +139,7 @@ int decoder_impl::work (int noutput_items,
 						}
 						else {
 							bit_distance=bit_counter-lastseen_offset_counter;
-							if (offset_pos[lastseen_offset]>=offset_pos[j]) 
+							if (offset_pos[lastseen_offset]>=offset_pos[j])
 								block_distance=offset_pos[j]+4-offset_pos[lastseen_offset];
 							else
 								block_distance=offset_pos[j]-offset_pos[lastseen_offset];

--- a/lib/decoder_impl.h
+++ b/lib/decoder_impl.h
@@ -62,4 +62,3 @@ private:
 } /* namespace gr */
 
 #endif /* INCLUDED_RDS_DECODER_IMPL_H */
-

--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -514,4 +514,3 @@ encoder::sptr encoder::make (unsigned char pty_locale, int pty, bool ms,
 					pi_country_code, pi_coverage_area, pi_reference_number,
 					radiotext));
 }
-

--- a/lib/encoder_impl.h
+++ b/lib/encoder_impl.h
@@ -107,5 +107,3 @@ private:
 } /* namespace gr */
 
 #endif /* INCLUDED_RDS_ENCODER_IMPL_H */
-
-

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -72,7 +72,7 @@ void parser_impl::reset() {
  * type 1 = PS
  * type 2 = PTY
  * type 3 = flagstring: TP, TA, MuSp, MoSt, AH, CMP, stPTY
- * type 4 = RadioText 
+ * type 4 = RadioText
  * type 5 = ClockTime
  * type 6 = Alternative Frequencies */
 void parser_impl::send_message(long msgtype, std::string msgtext) {
@@ -89,7 +89,7 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 	double af_1            = 0;
 	double af_2            = 0;
 	char flagstring[8]     = "0000000";
-	
+
 	traffic_program        = (group[1] >> 10) & 0x01;       // "TP"
 	traffic_announcement   = (group[1] >>  4) & 0x01;       // "TA"
 	music_speech           = (group[1] >>  3) & 0x01;       // "MuSp"
@@ -298,7 +298,7 @@ void parser_impl::decode_type3(unsigned int *group, bool B){
 	int group_type        =  group[1] & 0x1;
 	int message           =  group[2];
 	int aid               =  group[3];
-	
+
 	lout << "aid group: " << application_group
 		<< " " << (group_type ? 'B' : 'A');
 	if((application_group == 8) && (group_type == false)) { // 8A
@@ -434,7 +434,7 @@ void parser_impl::decode_optional_content(int no_groups, unsigned long int *free
 	int content        = 0;
 	int content_length = 0;
 	int ff_pointer     = 0;
-	
+
 	for (int i = no_groups; i == 0; i--){
 		ff_pointer = 12 + 16;
 		while(ff_pointer > 0){
@@ -470,18 +470,18 @@ void parser_impl::decode_type13(unsigned int *group, bool B){
 }
 
 void parser_impl::decode_type14(unsigned int *group, bool B){
-	
+
 	bool tp_on               = (group[1] >> 4) & 0x01;
 	char variant_code        = group[1] & 0x0f;
 	unsigned int information = group[2];
 	unsigned int pi_on       = group[3];
-	
+
 	char pty_on = 0;
 	bool ta_on = 0;
 	static char ps_on[8] = {' ',' ',' ',' ',' ',' ',' ',' '};
 	double af_1 = 0;
 	double af_2 = 0;
-	
+
 	if (!B){
 		switch (variant_code){
 			case 0: // PS(ON)
@@ -659,4 +659,3 @@ void parser_impl::parse(pmt::pmt_t pdu) {
 	}
 	dout << std::endl;
 }
-

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -79,4 +79,3 @@ private:
 } /* namespace gr */
 
 #endif /* INCLUDED_RDS_PARSER_IMPL_H */
-

--- a/lib/tmc_events.h
+++ b/lib/tmc_events.h
@@ -30,7 +30,7 @@
  * 2nd column: text (CEN-English)
  * 3rd column: event code (to be transmitted/received)
  * 4th column: quantifier type */
-static const std::string tmc_events[TMC_EVENTS][4]={
+static const char* tmc_events[TMC_EVENTS][4]={
 	{"0"," "," "," "},
 	{"1"," "," "," "},
 	{"2"," "," "," "},


### PR DESCRIPTION
This significantly reduces compile time, reduces the binary size by more than 800 kB, and keeps the compiler from exceeding its variable tracking size limit.

I also included a second commit which cleans up white space in the C files.