### PR TITLE
Fix parsing of optional content

### DIFF
--- a/lib/decoder_impl.h
+++ b/lib/decoder_impl.h
@@ -47,8 +47,8 @@ private:
 	unsigned int   group_good_blocks_counter;
 	unsigned int   group[4];
 	unsigned char  offset_chars[4];  // [ABCcDEx] (x=error)
-	bool           debug;
 	bool           log;
+	bool           debug;
 	bool           presync;
 	bool           good_block;
 	bool           group_assembly_started;

--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -139,7 +139,6 @@ void encoder_impl::rds_in(pmt::pmt_t msg) {
 	cout << "input string: " << in << "   length: " << in.size() << endl;
 
 	unsigned int ui1;
-	int i1;
 	std::string s1;
 	bool b1;
 	double d1;

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -439,10 +439,10 @@ void parser_impl::decode_optional_content(int no_groups, unsigned long int *free
 		ff_pointer = 12 + 16;
 		while(ff_pointer > 0){
 			ff_pointer -= 4;
-			label = (free_format[i] && (0xf << ff_pointer));
+			label = (free_format[i] >> ff_pointer) & 0xf;
 			content_length = optional_content_lengths[label];
 			ff_pointer -= content_length;
-			content = (free_format[i] && (int(pow(2, content_length) - 1) << ff_pointer));
+			content = (free_format[i] >> ff_pointer) & ((1 << content_length) - 1);
 			lout << "TMC optional content (" << label_descriptions[label]
 				<< "):" << content << std::endl;
 		}

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -69,8 +69,8 @@ private:
 	bool           artificial_head;
 	bool           compressed;
 	bool           static_pty;
-	bool           debug;
 	bool           log;
+	bool           debug;
 	unsigned char  pty_locale;
 	gr::thread::mutex d_mutex;
 };


### PR DESCRIPTION
The following warnings drew my attention to a couple bugs in `decode_optional_content`:
```
/home/argilo/prefix_next/src/gr-rds/lib/parser_impl.cc: In member function ‘void gr::rds::parser_impl::decode_optional_content(int, long unsigned int*)’:
/home/argilo/prefix_next/src/gr-rds/lib/parser_impl.cc:442:36: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
    label = (free_format[i] && (0xf << ff_pointer));
                               ~~~~~^~~~~~~~~~~~~~
/home/argilo/prefix_next/src/gr-rds/lib/parser_impl.cc:445:66: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
    content = (free_format[i] && (int(pow(2, content_length) - 1) << ff_pointer));
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```
This function is meant to extract packed bit fields from `free_format` but uses boolean AND instead of integer AND, and fails to right-shift the extracted bits.

I also included a second commit which silences some other compiler warnings.