### PR TITLE
Switch from boost:bind to std::bind

### DIFF
--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -39,7 +39,7 @@ encoder_impl::encoder_impl (unsigned char pty_locale, int pty, bool ms,
 	pty_locale(pty_locale) {
 
 	message_port_register_in(pmt::mp("rds in"));
-	set_msg_handler(pmt::mp("rds in"), boost::bind(&encoder_impl::rds_in, this, boost::placeholders::_1));
+	set_msg_handler(pmt::mp("rds in"), std::bind(&encoder_impl::rds_in, this, std::placeholders::_1));
 
 	std::memset(infoword,    0, sizeof(infoword));
 	std::memset(checkword,   0, sizeof(checkword));

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -40,7 +40,7 @@ parser_impl::parser_impl(bool log, bool debug, unsigned char pty_locale)
 	pty_locale(pty_locale)
 {
 	message_port_register_in(pmt::mp("in"));
-	set_msg_handler(pmt::mp("in"), boost::bind(&parser_impl::parse, this, boost::placeholders::_1));
+	set_msg_handler(pmt::mp("in"), std::bind(&parser_impl::parse, this, std::placeholders::_1));
 	message_port_register_out(pmt::mp("out"));
 	reset();
 }


### PR DESCRIPTION
gr-rds no longer builds on Ubuntu 16.04 because `bind::placeholders` (added in #34) requires Boost >= 1.60. I think a better solution would be to switch to `std::bind` which was added in C++11. gr-rds appears to work correctly after this change.