### PR TITLE
Fix typos

### DIFF
--- a/lib/constants.h
+++ b/lib/constants.h
@@ -122,7 +122,7 @@ const std::string rds_group_acronyms[16]={
 
 /* see page 84, Annex J in the standard */
 const std::string language_codes[44]={
-	"Unkown/not applicable",
+	"Unknown/not applicable",
 	"Albanian",
 	"Breton",
 	"Catalan",

--- a/lib/decoder_impl.cc
+++ b/lib/decoder_impl.cc
@@ -45,7 +45,7 @@ decoder_impl::~decoder_impl() {
 }
 
 
-////////////////////////// HELPER FUNTIONS /////////////////////////
+////////////////////////// HELPER FUNCTIONS /////////////////////////
 
 void decoder_impl::enter_no_sync() {
 	presync = false;


### PR DESCRIPTION
In https://github.com/csete/gqrx/pull/832 @luzpaz fixed many typos in Gqrx. Two of them came from gr-rds, so I'm upstreaming the fixes here.