### PR TITLE
Use unsigned char for radiotext & PS bytes

### DIFF
--- a/lib/encoder_impl.h
+++ b/lib/encoder_impl.h
@@ -48,8 +48,8 @@ private:
 
 	// FIXME make this a struct (or a class)
 	unsigned char PTY;
-	char radiotext[64];
-	char PS[8];
+	unsigned char radiotext[64];
+	unsigned char PS[8];
 	bool TA;
 	bool TP;
 	bool MS;


### PR DESCRIPTION
This fixes a problem where 8-bit characters are sign-extended before being packed into infowords.

https://github.com/bastibl/gr-rds/blob/d43ead61d1ff7fbea327868505fd27925c10f6f8/lib/encoder_impl.cc#L382

https://github.com/bastibl/gr-rds/blob/d43ead61d1ff7fbea327868505fd27925c10f6f8/lib/encoder_impl.cc#L389-L396

This can't be tested directly in GRC since it doesn't seem to allow `bytes` parameters. But I was able to test it by manually editing the generated Python code. After the change, accented characters can be transmitted.

Note: RDS uses a special character set; see page 42 here for details: https://www.etsi.org/deliver/etsi_ts/101700_101799/101756/01.06.01_60/ts_101756v010601p.pdf

Signed-off-by: Clayton Smith <argilo@gmail.com>