### PR TITLE
Fix bugs in the rds_tx example

### DIFF
--- a/examples/rds_tx.grc
+++ b/examples/rds_tx.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: RDS
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1600, 2048
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [16, 12]
     rotation: 0
     state: enabled
@@ -33,9 +36,12 @@ blocks:
   id: variable
   parameters:
     comment: ''
-    value: 80e3
+    value: 75e3
   states:
-    coordinate: [968, 12]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [888, 12.0]
     rotation: 0
     state: enabled
 - name: freq
@@ -44,16 +50,22 @@ blocks:
     comment: ''
     value: 87.5e6
   states:
-    coordinate: [1272, 13]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1192, 12.0]
     rotation: 0
     state: enabled
 - name: input_gain
   id: variable
   parameters:
     comment: ''
-    value: '0.3'
+    value: '0.26'
   states:
-    coordinate: [1040, 100]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1008, 84.0]
     rotation: 0
     state: enabled
 - name: outbuffer
@@ -62,25 +74,34 @@ blocks:
     comment: ''
     value: '10'
   states:
-    coordinate: [1080, 12]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1000, 12.0]
     rotation: 0
     state: enabled
 - name: pilot_gain
   id: variable
   parameters:
     comment: ''
-    value: '0.3'
+    value: '0.1'
   states:
-    coordinate: [1144, 100]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1104, 84.0]
     rotation: 0
     state: enabled
 - name: rds_gain
   id: variable
   parameters:
     comment: ''
-    value: '0.3'
+    value: 2000 / fm_max_dev
   states:
-    coordinate: [952, 100]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [888, 84.0]
     rotation: 0
     state: enabled
 - name: usrp_rate
@@ -89,7 +110,10 @@ blocks:
     comment: ''
     value: 19e3*20
   states:
-    coordinate: [1176, 12]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1096, 12.0]
     rotation: 0
     state: enabled
 - name: audio_source_0
@@ -102,85 +126,13 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     num_outputs: '2'
-    ok_to_block: 'True'
+    ok_to_block: 'False'
     samp_rate: '48000'
   states:
-    coordinate: [56, 1096]
-    rotation: 90
-    state: enabled
-- name: blocks_multiply_const_vxx_0
-  id: blocks_multiply_const_vxx
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    const: input_gain
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    type: float
-    vlen: '1'
-  states:
-    coordinate: [52, 776]
-    rotation: 90
-    state: enabled
-- name: blocks_multiply_const_vxx_0_0
-  id: blocks_multiply_const_vxx
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    const: rds_gain
-    maxoutbuf: outbuffer
-    minoutbuf: '0'
-    type: float
-    vlen: '1'
-  states:
-    coordinate: [1020, 424]
-    rotation: 270
-    state: enabled
-- name: blocks_multiply_const_vxx_0_0_1
-  id: blocks_multiply_const_vxx
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    const: pilot_gain
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    type: float
-    vlen: '1'
-  states:
-    coordinate: [376, 492]
-    rotation: 0
-    state: enabled
-- name: blocks_multiply_const_vxx_0_1
-  id: blocks_multiply_const_vxx
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    const: input_gain
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    type: float
-    vlen: '1'
-  states:
-    coordinate: [84, 920]
-    rotation: 90
-    state: enabled
-- name: blocks_repeat_0
-  id: blocks_repeat
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    interp: '160'
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    type: float
-    vlen: '1'
-  states:
-    coordinate: [432, 364]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 768.0]
     rotation: 0
     state: enabled
 - name: blocks_socket_pdu_0
@@ -197,9 +149,32 @@ blocks:
     tcp_no_delay: 'False'
     type: TCP_SERVER
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [32, 140.0]
     rotation: 0
     state: enabled
+- name: digital_chunks_to_symbols_xx_0
+  id: digital_chunks_to_symbols_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    dimension: '1'
+    in_type: byte
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_ports: '1'
+    out_type: float
+    symbol_table: '[-1, 1]'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 352.0]
+    rotation: 0
+    state: true
 - name: gr_add_xx_0
   id: blocks_add_xx
   parameters:
@@ -212,7 +187,10 @@ blocks:
     type: float
     vlen: '1'
   states:
-    coordinate: [440, 728]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [440, 728.0]
     rotation: 0
     state: enabled
 - name: gr_add_xx_1
@@ -227,34 +205,27 @@ blocks:
     type: float
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [816, 800]
     rotation: 270
-    state: enabled
-- name: gr_char_to_float_0
-  id: blocks_char_to_float
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    maxoutbuf: outbuffer
-    minoutbuf: '0'
-    scale: '1'
-    vlen: '1'
-  states:
-    coordinate: [232, 364]
-    rotation: 0
     state: enabled
 - name: gr_diff_encoder_bb_0
   id: digital_diff_encoder_bb
   parameters:
     affinity: ''
     alias: ''
+    coding: digital.DIFF_DIFFERENTIAL
     comment: ''
     maxoutbuf: outbuffer
     minoutbuf: '0'
     modulus: '2'
   states:
-    coordinate: [472, 164.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [472, 156.0]
     rotation: 0
     state: enabled
 - name: gr_frequency_modulator_fc_0
@@ -267,20 +238,10 @@ blocks:
     minoutbuf: '0'
     sensitivity: 2*math.pi*fm_max_dev/usrp_rate
   states:
-    coordinate: [720, 1036]
-    rotation: 180
-    state: enabled
-- name: gr_map_bb_0
-  id: digital_map_bb
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    map: '[-1,1]'
-    maxoutbuf: outbuffer
-    minoutbuf: '0'
-  states:
-    coordinate: [208, 308]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [720, 1044.0]
     rotation: 180
     state: enabled
 - name: gr_map_bb_1
@@ -293,7 +254,10 @@ blocks:
     maxoutbuf: outbuffer
     minoutbuf: '0'
   states:
-    coordinate: [528, 308]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [520, 300.0]
     rotation: 180
     state: enabled
 - name: gr_multiply_xx_0
@@ -308,7 +272,10 @@ blocks:
     type: float
     vlen: '1'
   states:
-    coordinate: [896, 336]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [904, 336.0]
     rotation: 0
     state: enabled
 - name: gr_multiply_xx_1
@@ -323,6 +290,9 @@ blocks:
     type: float
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [776, 601]
     rotation: 0
     state: enabled
@@ -337,10 +307,14 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: usrp_rate
     type: float
     waveform: analog.GR_SIN_WAVE
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [192, 568]
     rotation: 0
     state: enabled
@@ -349,17 +323,21 @@ blocks:
   parameters:
     affinity: ''
     alias: ''
-    amp: '1'
+    amp: rds_gain
     comment: ''
     freq: 57e3
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: usrp_rate
     type: float
     waveform: analog.GR_SIN_WAVE
   states:
-    coordinate: [704, 88]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [688, 124.0]
     rotation: 0
     state: enabled
 - name: gr_sig_source_x_0_1
@@ -367,17 +345,21 @@ blocks:
   parameters:
     affinity: ''
     alias: ''
-    amp: '1'
+    amp: pilot_gain
     comment: ''
     freq: 19e3
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: usrp_rate
     type: float
     waveform: analog.GR_SIN_WAVE
   states:
-    coordinate: [192, 464]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [192, 436.0]
     rotation: 0
     state: enabled
 - name: gr_sub_xx_0
@@ -392,7 +374,10 @@ blocks:
     type: float
     vlen: '1'
   states:
-    coordinate: [416, 872]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [424, 872.0]
     rotation: 0
     state: enabled
 - name: gr_unpack_k_bits_bb_0
@@ -405,7 +390,10 @@ blocks:
     maxoutbuf: outbuffer
     minoutbuf: '0'
   states:
-    coordinate: [328, 308]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 300.0]
     rotation: 180
     state: enabled
 - name: import_0
@@ -415,28 +403,10 @@ blocks:
     comment: ''
     imports: import math
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [192, 12]
-    rotation: 0
-    state: enabled
-- name: low_pass_filter_0
-  id: low_pass_filter
-  parameters:
-    affinity: ''
-    alias: ''
-    beta: '6.76'
-    comment: ''
-    cutoff_freq: 2.5e3
-    decim: '1'
-    gain: '1'
-    interp: '1'
-    maxoutbuf: outbuffer
-    minoutbuf: '0'
-    samp_rate: usrp_rate
-    type: interp_fir_filter_fff
-    width: .5e3
-    win: firdes.WIN_HAMMING
-  states:
-    coordinate: [680, 320]
     rotation: 0
     state: enabled
 - name: low_pass_filter_0_0
@@ -448,16 +418,19 @@ blocks:
     comment: ''
     cutoff_freq: 15e3
     decim: '1'
-    gain: '1'
+    gain: input_gain
     interp: '1'
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: usrp_rate
     type: interp_fir_filter_fff
     width: 2e3
-    win: firdes.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
-    coordinate: [552, 696]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [552, 692.0]
     rotation: 0
     state: enabled
 - name: low_pass_filter_0_0_0
@@ -469,16 +442,19 @@ blocks:
     comment: ''
     cutoff_freq: 15e3
     decim: '1'
-    gain: '1'
+    gain: input_gain
     interp: '1'
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: usrp_rate
     type: interp_fir_filter_fff
     width: 2e3
-    win: firdes.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
-    coordinate: [552, 840]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [552, 836.0]
     rotation: 0
     state: enabled
 - name: osmosdr_sink_0
@@ -720,10 +696,12 @@ blocks:
     if_gain7: '20'
     if_gain8: '20'
     if_gain9: '20'
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     sample_rate: 1e6
-    sync: ''
+    sync: sync
     time_source0: ''
     time_source1: ''
     time_source2: ''
@@ -734,7 +712,10 @@ blocks:
     time_source7: ''
     type: fc32
   states:
-    coordinate: [248, 1128]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [200, 1108.0]
     rotation: 180
     state: enabled
 - name: qtgui_freq_sink_x_0
@@ -770,7 +751,7 @@ blocks:
     ctrlpanel: 'False'
     fc: '0'
     fftsize: '1024'
-    freqhalf: 'True'
+    freqhalf: 'False'
     grid: 'False'
     gui_hint: ''
     label: Relative Gain
@@ -789,6 +770,7 @@ blocks:
     minoutbuf: '0'
     name: '""'
     nconnections: '1'
+    norm_window: 'False'
     showports: 'True'
     tr_chan: '0'
     tr_level: '0.0'
@@ -807,10 +789,13 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [936, 884]
     rotation: 0
     state: enabled
@@ -828,7 +813,10 @@ blocks:
     taps: ''
     type: fff
   states:
-    coordinate: [192, 704]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [208, 700.0]
     rotation: 0
     state: enabled
 - name: rational_resampler_xxx_0_0
@@ -845,7 +833,10 @@ blocks:
     taps: ''
     type: fff
   states:
-    coordinate: [192, 816]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [208, 804.0]
     rotation: 0
     state: enabled
 - name: rational_resampler_xxx_1
@@ -862,7 +853,10 @@ blocks:
     taps: ''
     type: ccc
   states:
-    coordinate: [520, 1016]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [520, 1020.0]
     rotation: 180
     state: enabled
 - name: rds_encoder_0
@@ -885,9 +879,35 @@ blocks:
     ta: 'False'
     tp: 'True'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [208, 84.0]
     rotation: 0
     state: true
+- name: root_raised_cosine_filter_0
+  id: root_raised_cosine_filter
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha: '1'
+    comment: ''
+    decim: '160'
+    gain: '111'
+    interp: '160'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    ntaps: 160*11
+    samp_rate: usrp_rate
+    sym_rate: '2375'
+    type: interp_fir_filter_fff
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [664, 324.0]
+    rotation: 0
+    state: enabled
 - name: uhd_usrp_sink
   id: uhd_usrp_sink
   parameters:
@@ -1033,6 +1053,38 @@ blocks:
     gain7: '0'
     gain8: '0'
     gain9: '0'
+    gain_type0: default
+    gain_type1: default
+    gain_type10: default
+    gain_type11: default
+    gain_type12: default
+    gain_type13: default
+    gain_type14: default
+    gain_type15: default
+    gain_type16: default
+    gain_type17: default
+    gain_type18: default
+    gain_type19: default
+    gain_type2: default
+    gain_type20: default
+    gain_type21: default
+    gain_type22: default
+    gain_type23: default
+    gain_type24: default
+    gain_type25: default
+    gain_type26: default
+    gain_type27: default
+    gain_type28: default
+    gain_type29: default
+    gain_type3: default
+    gain_type30: default
+    gain_type31: default
+    gain_type4: default
+    gain_type5: default
+    gain_type6: default
+    gain_type7: default
+    gain_type8: default
+    gain_type9: default
     len_tag_name: ''
     lo_export0: 'False'
     lo_export1: 'False'
@@ -1101,38 +1153,6 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     nchan: '1'
-    norm_gain0: 'False'
-    norm_gain1: 'False'
-    norm_gain10: 'False'
-    norm_gain11: 'False'
-    norm_gain12: 'False'
-    norm_gain13: 'False'
-    norm_gain14: 'False'
-    norm_gain15: 'False'
-    norm_gain16: 'False'
-    norm_gain17: 'False'
-    norm_gain18: 'False'
-    norm_gain19: 'False'
-    norm_gain2: 'False'
-    norm_gain20: 'False'
-    norm_gain21: 'False'
-    norm_gain22: 'False'
-    norm_gain23: 'False'
-    norm_gain24: 'False'
-    norm_gain25: 'False'
-    norm_gain26: 'False'
-    norm_gain27: 'False'
-    norm_gain28: 'False'
-    norm_gain29: 'False'
-    norm_gain3: 'False'
-    norm_gain30: 'False'
-    norm_gain31: 'False'
-    norm_gain4: 'False'
-    norm_gain5: 'False'
-    norm_gain6: 'False'
-    norm_gain7: 'False'
-    norm_gain8: 'False'
-    norm_gain9: 'False'
     num_mboards: '1'
     otw: ''
     samp_rate: 1e6
@@ -1145,6 +1165,7 @@ blocks:
     sd_spec6: ''
     sd_spec7: ''
     show_lo_controls: 'False'
+    start_time: '-1.0'
     stream_args: ''
     stream_chans: '[]'
     sync: sync
@@ -1158,35 +1179,31 @@ blocks:
     time_source7: ''
     type: fc32
   states:
-    coordinate: [224, 1012.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [224, 1004.0]
     rotation: 180
     state: disabled
 
 connections:
-- [audio_source_0, '0', blocks_multiply_const_vxx_0, '0']
-- [audio_source_0, '1', blocks_multiply_const_vxx_0_1, '0']
-- [blocks_multiply_const_vxx_0, '0', rational_resampler_xxx_0, '0']
-- [blocks_multiply_const_vxx_0_0, '0', gr_add_xx_1, '0']
-- [blocks_multiply_const_vxx_0_0_1, '0', gr_add_xx_1, '1']
-- [blocks_multiply_const_vxx_0_1, '0', rational_resampler_xxx_0_0, '0']
-- [blocks_repeat_0, '0', low_pass_filter_0, '0']
+- [audio_source_0, '0', rational_resampler_xxx_0, '0']
+- [audio_source_0, '1', rational_resampler_xxx_0_0, '0']
 - [blocks_socket_pdu_0, pdus, rds_encoder_0, rds in]
+- [digital_chunks_to_symbols_xx_0, '0', root_raised_cosine_filter_0, '0']
 - [gr_add_xx_0, '0', low_pass_filter_0_0, '0']
 - [gr_add_xx_1, '0', gr_frequency_modulator_fc_0, '0']
 - [gr_add_xx_1, '0', qtgui_freq_sink_x_0, '0']
-- [gr_char_to_float_0, '0', blocks_repeat_0, '0']
 - [gr_diff_encoder_bb_0, '0', gr_map_bb_1, '0']
 - [gr_frequency_modulator_fc_0, '0', rational_resampler_xxx_1, '0']
-- [gr_map_bb_0, '0', gr_char_to_float_0, '0']
 - [gr_map_bb_1, '0', gr_unpack_k_bits_bb_0, '0']
-- [gr_multiply_xx_0, '0', blocks_multiply_const_vxx_0_0, '0']
+- [gr_multiply_xx_0, '0', gr_add_xx_1, '0']
 - [gr_multiply_xx_1, '0', gr_add_xx_1, '2']
 - [gr_sig_source_x_0, '0', gr_multiply_xx_1, '0']
 - [gr_sig_source_x_0_0, '0', gr_multiply_xx_0, '0']
-- [gr_sig_source_x_0_1, '0', blocks_multiply_const_vxx_0_0_1, '0']
+- [gr_sig_source_x_0_1, '0', gr_add_xx_1, '1']
 - [gr_sub_xx_0, '0', low_pass_filter_0_0_0, '0']
-- [gr_unpack_k_bits_bb_0, '0', gr_map_bb_0, '0']
-- [low_pass_filter_0, '0', gr_multiply_xx_0, '1']
+- [gr_unpack_k_bits_bb_0, '0', digital_chunks_to_symbols_xx_0, '0']
 - [low_pass_filter_0_0, '0', gr_add_xx_1, '3']
 - [low_pass_filter_0_0_0, '0', gr_multiply_xx_1, '1']
 - [rational_resampler_xxx_0, '0', gr_add_xx_0, '0']
@@ -1196,6 +1213,7 @@ connections:
 - [rational_resampler_xxx_1, '0', osmosdr_sink_0, '0']
 - [rational_resampler_xxx_1, '0', uhd_usrp_sink, '0']
 - [rds_encoder_0, '0', gr_diff_encoder_bb_0, '0']
+- [root_raised_cosine_filter_0, '0', gr_multiply_xx_0, '1']
 
 metadata:
   file_format: 1


### PR DESCRIPTION
This commit fixes the following bugs in the RDS transmit example:
1. The filter window constants need to be updated for GNU Radio 3.9
2. The maximum FM deviation should be 75 kHz, not 80 kHz
3. The RDS gain should be set to produce a deviation of 2 kHz, not 24 
kHz
4. The pulse shaping filter should be RRC, not low-pass
5. The stereo pilot magnitude should be 10%, not 30%
6. The input gain needs to be reduced to avoid excess deviation

I also made the following changes:
* Removed unnecesary Multiply Const blocks
* Replaced Map & Char to Float blocks with a Chunks to Symbols block

Before:
![rds_tx_old](https://user-images.githubusercontent.com/583749/135485811-0aaf52fb-09aa-4e68-b13f-b1a97b25298f.png)

After:
![rds_tx_new](https://user-images.githubusercontent.com/583749/135485835-47242b41-4070-4cec-a353-bfed3920269c.png)

Signed-off-by: Clayton Smith <argilo@gmail.com>