### PR TITLE
Fix bugs in the rds_rx example

### DIFF
--- a/examples/rds_rx.grc
+++ b/examples/rds_rx.grc
@@ -27,11 +27,23 @@ options:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [14, 9]
+    coordinate: [16, 12.0]
     rotation: 0
     state: enabled
 
 blocks:
+- name: decimation
+  id: variable
+  parameters:
+    comment: ''
+    value: '8'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [296, 132.0]
+    rotation: 0
+    state: true
 - name: freq
   id: variable_qtgui_range
   parameters:
@@ -50,7 +62,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [729, 17]
+    coordinate: [728, 12.0]
     rotation: 0
     state: true
 - name: freq_offset
@@ -62,7 +74,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [208, 132]
+    coordinate: [200, 132.0]
     rotation: 0
     state: enabled
 - name: freq_tune
@@ -74,7 +86,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [112, 132]
+    coordinate: [104, 132.0]
     rotation: 0
     state: enabled
 - name: gain
@@ -95,7 +107,54 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [650, 16]
+    coordinate: [608, 12.0]
+    rotation: 0
+    state: true
+- name: pilot_taps
+  id: variable_band_pass_filter_taps
+  parameters:
+    beta: '6.76'
+    comment: ''
+    gain: '1.0'
+    high_cutoff_freq: '19020'
+    low_cutoff_freq: '18980'
+    samp_rate: '240000'
+    type: complex_band_pass
+    width: '1000'
+    win: window.WIN_HAMMING
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1040, 12.0]
+    rotation: 0
+    state: true
+- name: rrc_taps
+  id: variable_rrc_filter_taps
+  parameters:
+    alpha: '1.0'
+    comment: ''
+    gain: '1.0'
+    ntaps: '151'
+    samp_rate: '19000'
+    sym_rate: 19000/8
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [24, 604.0]
+    rotation: 0
+    state: true
+- name: rrc_taps_manchester
+  id: variable
+  parameters:
+    comment: ''
+    value: '[rrc_taps[n] - rrc_taps[n+8] for n in range(len(rrc_taps)-8)]'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [24, 732.0]
     rotation: 0
     state: true
 - name: samp_rate
@@ -122,14 +181,34 @@ blocks:
     start: '-20'
     step: '1'
     stop: '10'
-    value: '0'
+    value: '-6'
     widget: counter_slider
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [818, 15]
+    coordinate: [856, 12.0]
     rotation: 0
+    state: true
+- name: analog_agc_xx_0
+  id: analog_agc_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    gain: 106/2
+    max_gain: '1000'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    rate: 2e-3
+    reference: 0.702*0+0.585
+    type: complex
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [196.0, 712]
+    rotation: 270
     state: true
 - name: analog_fm_deemph_0_0
   id: analog_fm_deemph
@@ -145,7 +224,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1036.0, 656]
+    coordinate: [1452.0, 616]
     rotation: 270
     state: enabled
 - name: analog_fm_deemph_0_0_0
@@ -162,26 +241,43 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1172.0, 656]
+    coordinate: [1380.0, 616]
     rotation: 270
     state: enabled
-- name: analog_wfm_rcv_0
-  id: analog_wfm_rcv
+- name: analog_pll_refout_cc_0
+  id: analog_pll_refout_cc
   parameters:
     affinity: ''
     alias: ''
-    audio_decimation: '8'
     comment: ''
+    max_freq: 2 * math.pi * 19020 / 240000
     maxoutbuf: '0'
+    min_freq: 2 * math.pi * 18980 / 240000
     minoutbuf: '0'
-    quad_rate: samp_rate
+    w: '0.001'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [496, 276.0]
+    coordinate: [876.0, 568]
+    rotation: 270
+    state: true
+- name: analog_quadrature_demod_cf_0
+  id: analog_quadrature_demod_cf
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    gain: (samp_rate / decimation) / (2*math.pi*75000)
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [520, 284.0]
     rotation: 0
-    state: enabled
+    state: true
 - name: audio_sink_0
   id: audio_sink
   parameters:
@@ -196,8 +292,8 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1416, 772.0]
-    rotation: 0
+    coordinate: [1416.0, 992]
+    rotation: 270
     state: enabled
 - name: blocks_add_xx_0
   id: blocks_add_xx
@@ -214,11 +310,11 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1156.0, 536]
+    coordinate: [1376.0, 512]
     rotation: 270
     state: enabled
-- name: blocks_complex_to_real_0
-  id: blocks_complex_to_real
+- name: blocks_complex_to_imag_0
+  id: blocks_complex_to_imag
   parameters:
     affinity: ''
     alias: ''
@@ -230,27 +326,28 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1172.0, 296]
-    rotation: 270
+    coordinate: [976.0, 504]
+    rotation: 90
     state: enabled
-- name: blocks_keep_one_in_n_0
-  id: blocks_keep_one_in_n
+- name: blocks_delay_0
+  id: blocks_delay
   parameters:
     affinity: ''
     alias: ''
     comment: ''
+    delay: (len(pilot_taps) - 1) // 2
     maxoutbuf: '0'
     minoutbuf: '0'
-    n: '2'
-    type: byte
+    num_ports: '1'
+    type: float
     vlen: '1'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [488, 668.0]
+    coordinate: [952, 288.0]
     rotation: 0
-    state: enabled
+    state: true
 - name: blocks_multiply_const_vxx_0
   id: blocks_multiply_const_vxx
   parameters:
@@ -266,8 +363,8 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1248, 764.0]
-    rotation: 0
+    coordinate: [1388.0, 784]
+    rotation: 270
     state: enabled
 - name: blocks_multiply_const_vxx_0_0
   id: blocks_multiply_const_vxx
@@ -284,9 +381,45 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1248, 812.0]
-    rotation: 0
+    coordinate: [1460.0, 784]
+    rotation: 270
     state: enabled
+- name: blocks_multiply_xx_0
+  id: blocks_multiply_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [960.0, 680]
+    rotation: 90
+    state: true
+- name: blocks_multiply_xx_1
+  id: blocks_multiply_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1056, 384.0]
+    rotation: 0
+    state: true
 - name: blocks_sub_xx_0
   id: blocks_sub_xx
   parameters:
@@ -302,14 +435,35 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1020.0, 528]
+    coordinate: [1448.0, 488]
     rotation: 270
     state: enabled
+- name: digital_constellation_receiver_cb_0
+  id: digital_constellation_receiver_cb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    constellation: digital.constellation_bpsk().base()
+    fmax: '0.002'
+    fmin: '-0.002'
+    loop_bw: 2*math.pi / 100
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    showports: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [648, 800.0]
+    rotation: 0
+    state: true
 - name: digital_diff_decoder_bb_0
   id: digital_diff_decoder_bb
   parameters:
     affinity: ''
     alias: ''
+    coding: digital.DIFF_DIFFERENTIAL
     comment: ''
     maxoutbuf: '0'
     minoutbuf: '0'
@@ -318,34 +472,55 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [624, 668.0]
-    rotation: 0
+    coordinate: [688, 980.0]
+    rotation: 180
     state: enabled
-- name: digital_psk_demod_0
-  id: digital_psk_demod
+- name: digital_symbol_sync_xx_0
+  id: digital_symbol_sync_xx
   parameters:
     affinity: ''
     alias: ''
     comment: ''
-    constellation_points: '2'
-    differential: 'False'
-    excess_bw: '0.35'
-    freq_bw: 6.28/100.0
-    log: 'False'
+    constellation: digital.constellation_bpsk().base()
+    damping: '1.0'
+    loop_bw: '0.01'
+    max_dev: '0.1'
     maxoutbuf: '0'
     minoutbuf: '0'
-    mod_code: '"gray"'
-    phase_bw: 6.28/100.0
-    samples_per_symbol: '4'
-    timing_bw: 6.28/100.0
-    verbose: 'False'
+    nfilters: '128'
+    osps: '1'
+    pfb_mf_taps: '[]'
+    resamp_type: digital.IR_MMSE_8TAP
+    sps: '16'
+    ted_gain: '1.0'
+    ted_type: digital.TED_ZERO_CROSSING
+    type: cc
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [272, 636.0]
+    coordinate: [320, 804.0]
     rotation: 0
-    state: enabled
+    state: true
+- name: fir_filter_xxx_0
+  id: fir_filter_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_delay: '0'
+    taps: pilot_taps
+    type: fcc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [884.0, 376]
+    rotation: 270
+    state: true
 - name: fir_filter_xxx_1
   id: fir_filter_xxx
   parameters:
@@ -356,14 +531,52 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_delay: '0'
-    taps: firdes.low_pass(1.0,240000,13e3,3e3)
+    taps: firdes.low_pass(1.0,240000,15e3,2e3)
     type: fff
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [952, 348.0]
+    coordinate: [1176, 292.0]
     rotation: 0
+    state: enabled
+- name: fir_filter_xxx_1_0
+  id: fir_filter_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '5'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_delay: '0'
+    taps: firdes.low_pass(-2.1,240000,15e3,2e3)
+    type: fff
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1176, 388.0]
+    rotation: 0
+    state: enabled
+- name: fir_filter_xxx_2
+  id: fir_filter_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_delay: '0'
+    taps: rrc_taps_manchester
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 612.0]
+    rotation: 180
     state: enabled
 - name: freq_xlating_fir_filter_xxx_0
   id: freq_xlating_fir_filter_xxx
@@ -372,11 +585,11 @@ blocks:
     alias: ''
     center_freq: freq_offset
     comment: ''
-    decim: '1'
+    decim: decimation
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: samp_rate
-    taps: firdes.low_pass(1, samp_rate, 80000, 20000)
+    taps: firdes.low_pass(1, samp_rate, 100000, 20000)
     type: ccc
   states:
     bus_sink: false
@@ -392,38 +605,18 @@ blocks:
     alias: ''
     center_freq: 57e3
     comment: ''
-    decim: '1'
+    decim: '10'
     maxoutbuf: '0'
     minoutbuf: '0'
-    samp_rate: '250000'
-    taps: firdes.low_pass(2500.0,250000,2.6e3,2e3)
+    samp_rate: samp_rate / decimation
+    taps: firdes.low_pass(1.0, samp_rate / decimation, 2.4e3, 10e3)
     type: fcc
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [628.0, 384]
+    coordinate: [668.0, 376]
     rotation: 270
-    state: enabled
-- name: freq_xlating_fir_filter_xxx_2
-  id: freq_xlating_fir_filter_xxx
-  parameters:
-    affinity: ''
-    alias: ''
-    center_freq: '38000'
-    comment: ''
-    decim: '5'
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    samp_rate: '240000'
-    taps: firdes.low_pass(1.0,240000,13e3,3e3)
-    type: fcf
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [952, 236.0]
-    rotation: 0
     state: enabled
 - name: import_0
   id: import
@@ -435,7 +628,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [184, 12]
+    coordinate: [184, 12.0]
     rotation: 0
     state: enabled
 - name: note_0
@@ -448,7 +641,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [952, 392.0]
+    coordinate: [1176, 244.0]
     rotation: 180
     state: enabled
 - name: note_0_1
@@ -461,7 +654,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [952, 200.0]
+    coordinate: [1176, 452.0]
     rotation: 0
     state: enabled
 - name: note_0_2
@@ -474,51 +667,22 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [552, 400.0]
-    rotation: 180
+    coordinate: [620.0, 376]
+    rotation: 90
     state: enabled
-- name: pfb_arb_resampler_xxx_0
-  id: pfb_arb_resampler_xxx
+- name: note_1
+  id: note
   parameters:
-    affinity: ''
     alias: ''
-    atten: '100'
     comment: ''
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    nfilts: '32'
-    rrate: 19000/250e3
-    samp_delay: '0'
-    taps: ''
-    type: ccf
+    note: Pilot
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [480, 528.0]
-    rotation: 180
-    state: enabled
-- name: pfb_arb_resampler_xxx_1
-  id: pfb_arb_resampler_xxx
-  parameters:
-    affinity: ''
-    alias: ''
-    atten: '100'
-    comment: ''
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    nfilts: '32'
-    rrate: 240000.0/250000
-    samp_delay: '0'
-    taps: ''
-    type: fff
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [728, 264.0]
-    rotation: 0
-    state: enabled
+    coordinate: [836.0, 376]
+    rotation: 270
+    state: true
 - name: qtgui_freq_sink_x_0
   id: qtgui_freq_sink_x
   parameters:
@@ -537,7 +701,7 @@ blocks:
     autoscale: 'False'
     average: '1.0'
     axislabels: 'True'
-    bw: samp_rate
+    bw: samp_rate / decimation
     color1: '"blue"'
     color10: '"dark blue"'
     color2: '"red"'
@@ -597,9 +761,9 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [497, 157]
+    coordinate: [512, 180.0]
     rotation: 0
-    state: true
+    state: enabled
 - name: qtgui_waterfall_sink_x_0
   id: qtgui_waterfall_sink_x
   parameters:
@@ -616,7 +780,7 @@ blocks:
     alpha8: '1.0'
     alpha9: '1.0'
     axislabels: 'True'
-    bw: samp_rate
+    bw: samp_rate / decimation
     color1: '0'
     color10: '0'
     color2: '0'
@@ -630,11 +794,11 @@ blocks:
     comment: ''
     fc: '0'
     fftsize: '1024'
-    freqhalf: 'True'
+    freqhalf: 'False'
     grid: 'False'
     gui_hint: ''
-    int_max: '10'
-    int_min: '-140'
+    int_max: '0'
+    int_min: '-80'
     label1: ''
     label10: ''
     label2: ''
@@ -658,8 +822,48 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [728, 196.0]
+    coordinate: [728, 180.0]
     rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: samp_rate // decimation
+    fbw: '0'
+    interp: '240000'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: '[]'
+    type: fff
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [736, 260.0]
+    rotation: 0
+    state: true
+- name: rational_resampler_xxx_1
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: samp_rate // decimation // 10
+    fbw: '0'
+    interp: '19000'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: '[]'
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [512, 596.0]
+    rotation: 180
     state: true
 - name: rds_decoder_0
   id: rds_decoder
@@ -675,7 +879,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [656, 804.0]
+    coordinate: [536, 980.0]
     rotation: 180
     state: true
 - name: rds_panel_0
@@ -690,7 +894,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [320, 816.0]
+    coordinate: [208, 992.0]
     rotation: 180
     state: true
 - name: rds_parser_0
@@ -709,32 +913,9 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [480, 796.0]
+    coordinate: [360, 972.0]
     rotation: 180
     state: true
-- name: root_raised_cosine_filter_0
-  id: root_raised_cosine_filter
-  parameters:
-    affinity: ''
-    alias: ''
-    alpha: '1'
-    comment: ''
-    decim: '2'
-    gain: '1'
-    interp: '1'
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    ntaps: '100'
-    samp_rate: '19000'
-    sym_rate: '2375'
-    type: fir_filter_ccf
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [280, 516.0]
-    rotation: 180
-    state: enabled
 - name: rtlsdr_source_0_0
   id: rtlsdr_source
   parameters:
@@ -773,7 +954,7 @@ blocks:
     ant8: ''
     ant9: ''
     args: ''
-    bb_gain0: gain
+    bb_gain0: '20'
     bb_gain1: '20'
     bb_gain10: '20'
     bb_gain11: '20'
@@ -942,7 +1123,7 @@ blocks:
     freq7: 100e6
     freq8: 100e6
     freq9: 100e6
-    gain0: '14'
+    gain0: gain
     gain1: '10'
     gain10: '10'
     gain11: '10'
@@ -1006,7 +1187,7 @@ blocks:
     gain_mode7: 'False'
     gain_mode8: 'False'
     gain_mode9: 'False'
-    if_gain0: '24'
+    if_gain0: '20'
     if_gain1: '20'
     if_gain10: '20'
     if_gain11: '20'
@@ -1089,7 +1270,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [71, 356]
+    coordinate: [24, 356.0]
     rotation: 0
     state: enabled
 - name: uhd_usrp_source_0
@@ -1525,37 +1706,45 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [41, 231]
+    coordinate: [40, 228.0]
     rotation: 0
     state: disabled
 
 connections:
+- [analog_agc_xx_0, '0', digital_symbol_sync_xx_0, '0']
 - [analog_fm_deemph_0_0, '0', blocks_multiply_const_vxx_0_0, '0']
 - [analog_fm_deemph_0_0_0, '0', blocks_multiply_const_vxx_0, '0']
-- [analog_wfm_rcv_0, '0', freq_xlating_fir_filter_xxx_1_0, '0']
-- [analog_wfm_rcv_0, '0', pfb_arb_resampler_xxx_1, '0']
-- [analog_wfm_rcv_0, '0', qtgui_waterfall_sink_x_0, '0']
+- [analog_pll_refout_cc_0, '0', blocks_multiply_xx_0, '0']
+- [analog_pll_refout_cc_0, '0', blocks_multiply_xx_0, '1']
+- [analog_quadrature_demod_cf_0, '0', freq_xlating_fir_filter_xxx_1_0, '0']
+- [analog_quadrature_demod_cf_0, '0', qtgui_waterfall_sink_x_0, '0']
+- [analog_quadrature_demod_cf_0, '0', rational_resampler_xxx_0, '0']
 - [blocks_add_xx_0, '0', analog_fm_deemph_0_0_0, '0']
-- [blocks_complex_to_real_0, '0', blocks_add_xx_0, '1']
-- [blocks_complex_to_real_0, '0', blocks_sub_xx_0, '1']
-- [blocks_keep_one_in_n_0, '0', digital_diff_decoder_bb_0, '0']
+- [blocks_complex_to_imag_0, '0', blocks_multiply_xx_1, '1']
+- [blocks_delay_0, '0', blocks_multiply_xx_1, '0']
+- [blocks_delay_0, '0', fir_filter_xxx_1, '0']
 - [blocks_multiply_const_vxx_0, '0', audio_sink_0, '0']
 - [blocks_multiply_const_vxx_0_0, '0', audio_sink_0, '1']
+- [blocks_multiply_xx_0, '0', blocks_complex_to_imag_0, '0']
+- [blocks_multiply_xx_1, '0', fir_filter_xxx_1_0, '0']
 - [blocks_sub_xx_0, '0', analog_fm_deemph_0_0, '0']
+- [digital_constellation_receiver_cb_0, '0', digital_diff_decoder_bb_0, '0']
 - [digital_diff_decoder_bb_0, '0', rds_decoder_0, '0']
-- [digital_psk_demod_0, '0', blocks_keep_one_in_n_0, '0']
+- [digital_symbol_sync_xx_0, '0', digital_constellation_receiver_cb_0, '0']
+- [fir_filter_xxx_0, '0', analog_pll_refout_cc_0, '0']
 - [fir_filter_xxx_1, '0', blocks_add_xx_0, '0']
 - [fir_filter_xxx_1, '0', blocks_sub_xx_0, '0']
-- [freq_xlating_fir_filter_xxx_0, '0', analog_wfm_rcv_0, '0']
+- [fir_filter_xxx_1_0, '0', blocks_add_xx_0, '1']
+- [fir_filter_xxx_1_0, '0', blocks_sub_xx_0, '1']
+- [fir_filter_xxx_2, '0', analog_agc_xx_0, '0']
+- [freq_xlating_fir_filter_xxx_0, '0', analog_quadrature_demod_cf_0, '0']
 - [freq_xlating_fir_filter_xxx_0, '0', qtgui_freq_sink_x_0, '0']
-- [freq_xlating_fir_filter_xxx_1_0, '0', pfb_arb_resampler_xxx_0, '0']
-- [freq_xlating_fir_filter_xxx_2, '0', blocks_complex_to_real_0, '0']
-- [pfb_arb_resampler_xxx_0, '0', root_raised_cosine_filter_0, '0']
-- [pfb_arb_resampler_xxx_1, '0', fir_filter_xxx_1, '0']
-- [pfb_arb_resampler_xxx_1, '0', freq_xlating_fir_filter_xxx_2, '0']
+- [freq_xlating_fir_filter_xxx_1_0, '0', rational_resampler_xxx_1, '0']
+- [rational_resampler_xxx_0, '0', blocks_delay_0, '0']
+- [rational_resampler_xxx_0, '0', fir_filter_xxx_0, '0']
+- [rational_resampler_xxx_1, '0', fir_filter_xxx_2, '0']
 - [rds_decoder_0, out, rds_parser_0, in]
 - [rds_parser_0, out, rds_panel_0, in]
-- [root_raised_cosine_filter_0, '0', digital_psk_demod_0, '0']
 - [rtlsdr_source_0_0, '0', freq_xlating_fir_filter_xxx_0, '0']
 - [uhd_usrp_source_0, '0', freq_xlating_fir_filter_xxx_0, '0']
 


### PR DESCRIPTION
The rds_rx.grc example has a number of problems:

1. FM stereo does not work, because the receiver does not recover the phase of the 19 kHz stereo pilot.
2. The WBFM Receive block applies FM deemphasis too early. Deemphasis should be applied after stereo demodulation.
3. The gain slider does not work for the RTL-SDR source.
4. The default audio gain is too high, causing clipping.
5. A deprecated block is used (PSK Demod).
6. The RDS receive chain doesn't have AGC.
7. The RDS receiver throws away half of each Manchester symbol, degrading receive performance by 3 dB.

In this commit I've fixed these problems. I verified that stereo demod now works, and that RDS receive performance is improved.

Before:
![rds_rx_old](https://user-images.githubusercontent.com/583749/135486430-9d4fe1b1-5189-4237-b4d4-f48a67caa05e.png)

After:
![rds_rx_new](https://user-images.githubusercontent.com/583749/135486455-88a69baa-d4ba-463d-96f6-9525b1c83550.png)

Signed-off-by: Clayton Smith <argilo@gmail.com>