### PR TITLE
Initialize bit_counter and reg

### DIFF
--- a/lib/decoder_impl.cc
+++ b/lib/decoder_impl.cc
@@ -33,6 +33,8 @@ decoder_impl::decoder_impl(bool log, bool debug)
 	: gr::sync_block ("gr_rds_decoder",
 			gr::io_signature::make (1, 1, sizeof(char)),
 			gr::io_signature::make (0, 0, 0)),
+	bit_counter(0),
+	reg(0),
 	log(log),
 	debug(debug)
 {


### PR DESCRIPTION
Valgrind reports that `decoder_impl::work` uses the `bit_counter` and `reg` member variables before they are initialized, leading to undefined behaviour. After explicitly initializing them to zero, the valgrind warnings go away.