### PR TITLE
Replace std::bind with lambda expressions

### DIFF
--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -39,7 +39,7 @@ encoder_impl::encoder_impl (unsigned char pty_locale, int pty, bool ms,
 	pty_locale(pty_locale) {
 
 	message_port_register_in(pmt::mp("rds in"));
-	set_msg_handler(pmt::mp("rds in"), std::bind(&encoder_impl::rds_in, this, std::placeholders::_1));
+	set_msg_handler(pmt::mp("rds in"), [this](pmt::pmt_t msg) { this->rds_in(msg); });
 
 	std::memset(infoword,    0, sizeof(infoword));
 	std::memset(checkword,   0, sizeof(checkword));

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -42,7 +42,7 @@ parser_impl::parser_impl(bool log, bool debug, unsigned char pty_locale)
 	pty_locale(pty_locale)
 {
 	message_port_register_in(pmt::mp("in"));
-	set_msg_handler(pmt::mp("in"), std::bind(&parser_impl::parse, this, std::placeholders::_1));
+	set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->parse(msg); });
 	message_port_register_out(pmt::mp("out"));
 	reset();
 }


### PR DESCRIPTION
GNU Radio uses lambda expressions for all its message handlers, so it makes sense to do so in OOT modules as well.