### PR TITLE
Update Socket PDU block for GNU Radio 3.10

### DIFF
--- a/examples/rds_tx.grc
+++ b/examples/rds_tx.grc
@@ -23,6 +23,7 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
+    window_size: (1000,1000)
   states:
     bus_sink: false
     bus_source: false
@@ -133,26 +134,6 @@ blocks:
     bus_source: false
     bus_structure: null
     coordinate: [16, 768.0]
-    rotation: 0
-    state: enabled
-- name: blocks_socket_pdu_0
-  id: blocks_socket_pdu
-  parameters:
-    affinity: ''
-    alias: ''
-    comment: ''
-    host: ''
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    mtu: '10000'
-    port: '52001'
-    tcp_no_delay: 'False'
-    type: TCP_SERVER
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [32, 140.0]
     rotation: 0
     state: enabled
 - name: digital_chunks_to_symbols_xx_0
@@ -455,6 +436,26 @@ blocks:
     bus_source: false
     bus_structure: null
     coordinate: [552, 836.0]
+    rotation: 0
+    state: enabled
+- name: network_socket_pdu_0
+  id: network_socket_pdu
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    host: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mtu: '10000'
+    port: '52001'
+    tcp_no_delay: 'False'
+    type: TCP_SERVER
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [32, 140.0]
     rotation: 0
     state: enabled
 - name: osmosdr_sink_0
@@ -1189,7 +1190,6 @@ blocks:
 connections:
 - [audio_source_0, '0', rational_resampler_xxx_0, '0']
 - [audio_source_0, '1', rational_resampler_xxx_0_0, '0']
-- [blocks_socket_pdu_0, pdus, rds_encoder_0, rds in]
 - [digital_chunks_to_symbols_xx_0, '0', root_raised_cosine_filter_0, '0']
 - [gr_add_xx_0, '0', low_pass_filter_0_0, '0']
 - [gr_add_xx_1, '0', gr_frequency_modulator_fc_0, '0']
@@ -1206,6 +1206,7 @@ connections:
 - [gr_unpack_k_bits_bb_0, '0', digital_chunks_to_symbols_xx_0, '0']
 - [low_pass_filter_0_0, '0', gr_add_xx_1, '3']
 - [low_pass_filter_0_0_0, '0', gr_multiply_xx_1, '1']
+- [network_socket_pdu_0, pdus, rds_encoder_0, rds in]
 - [rational_resampler_xxx_0, '0', gr_add_xx_0, '0']
 - [rational_resampler_xxx_0, '0', gr_sub_xx_0, '0']
 - [rational_resampler_xxx_0_0, '0', gr_add_xx_0, '1']
@@ -1217,3 +1218,4 @@ connections:
 
 metadata:
   file_format: 1
+  grc_version: 3.10.2.0


### PR DESCRIPTION
The Socket PDU block moved to the gr-network module in GNU Radio 3.10, so the rds_tx flow graph needs to be updated accordingly. I've done that here.