### PR TITLE
Correctly parse mono/stereo DI code

### DIFF
--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -163,7 +163,7 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 		<< "<== -" << (traffic_program ? "TP" : "  ")
 		<< '-' << (traffic_announcement ? "TA" : "  ")
 		<< '-' << (music_speech ? "Music" : "Speech")
-		<< '-' << (mono_stereo ? "MONO" : "STEREO")
+		<< '-' << (mono_stereo ? "STEREO" : "MONO")
 		<< " - AF:" << af_string << std::endl;
 
 	send_message(1, std::string(program_service_name, 8));

--- a/python/rdspanel.py
+++ b/python/rdspanel.py
@@ -149,10 +149,10 @@ class rdsPanel(gr.sync_block, QtWidgets.QWidget):
                                 self.music.setText("Speech")
                                 self.music.setStyleSheet("font-weight: bold; color: red")
                         if (flags[3]=='1'):
-                                self.stereo.setText("Mono")
+                                self.stereo.setText("Stereo")
                                 self.stereo.setStyleSheet("font-weight: bold; color: red")
                         else:
-                                self.stereo.setText("Stereo")
+                                self.stereo.setText("Mono")
                                 self.stereo.setStyleSheet("font-weight: bold; color: red")
                         if (flags[4]=='1'):
                                 self.AH.setStyleSheet("font-weight: bold; color: red")


### PR DESCRIPTION
Fixes #65.

As noted in that issue, the NRSC-4-A standard states that 0 indicates Mono, and 1 indicates Stereo.

The mono/stereo field was removed in IEC-62106-2:2018, so we might consider removing it from gr-rds in the future.