### PR TITLE
Fix decoding of DI bits

### DIFF
--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -67,7 +67,7 @@ void parser_impl::reset() {
 	mono_stereo                    = false;
 	artificial_head                = false;
 	compressed                     = false;
-	static_pty                     = false;
+	dynamic_pty                    = false;
 }
 
 /* type 0 = PI
@@ -105,16 +105,16 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 	/* see page 41, table 9 of the standard */
 	switch (segment_address) {
 		case 0:
-			mono_stereo=decoder_control_bit;
+			dynamic_pty=decoder_control_bit;
 		break;
 		case 1:
-			artificial_head=decoder_control_bit;
-		break;
-		case 2:
 			compressed=decoder_control_bit;
 		break;
+		case 2:
+			artificial_head=decoder_control_bit;
+		break;
 		case 3:
-			static_pty=decoder_control_bit;
+			mono_stereo=decoder_control_bit;
 		break;
 		default:
 		break;
@@ -125,7 +125,7 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 	flagstring[3] = mono_stereo            ? '1' : '0';
 	flagstring[4] = artificial_head        ? '1' : '0';
 	flagstring[5] = compressed             ? '1' : '0';
-	flagstring[6] = static_pty             ? '1' : '0';
+	flagstring[6] = dynamic_pty            ? '1' : '0';
 	static std::string af_string;
 
 	if(!B) { // type 0A

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -68,7 +68,7 @@ private:
 	bool           mono_stereo;
 	bool           artificial_head;
 	bool           compressed;
-	bool           static_pty;
+	bool           dynamic_pty;
 	bool           log;
 	bool           debug;
 	unsigned char  pty_locale;

--- a/python/rdspanel.py
+++ b/python/rdspanel.py
@@ -162,7 +162,7 @@ class rdsPanel(gr.sync_block, QtWidgets.QWidget):
                                 self.CMP.setStyleSheet("font-weight: bold; color: red")
                         else:
                                 self.CMP.setStyleSheet("font-weight: bold; color: gray")
-                        if (flags[6]=='1'):
+                        if (flags[6]=='0'):
                                 self.stPTY.setStyleSheet("font-weight: bold; color: red")
                         else:
                                 self.stPTY.setStyleSheet("font-weight: bold; color: gray")


### PR DESCRIPTION
@KubaPro010 reported in https://github.com/gqrx-sdr/gqrx/issues/1360 that DI bits (mono/stereo, dynamic head, etc) are not parsed correctly in Gqrx, and @vladisslav2011 proposed a fix in https://github.com/gqrx-sdr/gqrx/pull/1361. Because Gqrx has copied `parser_impl.cc` and `parser_impl.h` from gr-rds, I would like to propose the changes upstream before accepting them in Gqrx.

Two issues are fixed here:

1. The order of the four DI bits was reversed.
2. The sense of the Static PTY / Dynamic PTY bit was inverted.

I tested this out with some local stations, and Mono/Stereo is now correctly indicated in the panel.