### PR TITLE
Generate stereo & RDS subcarriers from pilot tone

### DIFF
--- a/examples/rds_tx.grc
+++ b/examples/rds_tx.grc
@@ -42,7 +42,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [888, 12.0]
+    coordinate: [888, 8.0]
     rotation: 0
     state: enabled
 - name: freq
@@ -54,7 +54,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1192, 12.0]
+    coordinate: [1200, 8.0]
     rotation: 0
     state: enabled
 - name: input_gain
@@ -79,7 +79,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1000, 12.0]
+    coordinate: [1008, 8.0]
     rotation: 0
     state: enabled
 - name: pilot_gain
@@ -115,7 +115,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1096, 12.0]
+    coordinate: [1104, 8.0]
     rotation: 0
     state: enabled
 - name: analog_fm_preemph_0
@@ -133,7 +133,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [232, 708.0]
+    coordinate: [232, 704.0]
     rotation: 0
     state: enabled
 - name: analog_fm_preemph_0_0
@@ -154,6 +154,29 @@ blocks:
     coordinate: [232, 828.0]
     rotation: 0
     state: enabled
+- name: analog_sig_source_x_0_1
+  id: analog_sig_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: '1'
+    comment: ''
+    freq: '19000'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: '0'
+    phase: '0'
+    samp_rate: usrp_rate
+    showports: 'False'
+    type: complex
+    waveform: analog.GR_COS_WAVE
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 488.0]
+    rotation: 0
+    state: enabled
 - name: audio_source_0
   id: audio_source
   parameters:
@@ -171,6 +194,126 @@ blocks:
     bus_source: false
     bus_structure: null
     coordinate: [16, 768.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_imag_0
+  id: blocks_complex_to_imag
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [496, 624.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_imag_0_0
+  id: blocks_complex_to_imag
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [592, 552.0]
+    rotation: 0
+    state: enabled
+- name: blocks_complex_to_imag_0_0_0
+  id: blocks_complex_to_imag
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [592, 472.0]
+    rotation: 0
+    state: enabled
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    const: pilot_gain
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [696, 616.0]
+    rotation: 0
+    state: enabled
+- name: blocks_multiply_const_vxx_1
+  id: blocks_multiply_const_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    const: rds_gain
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [776, 464.0]
+    rotation: 0
+    state: enabled
+- name: blocks_multiply_xx_0
+  id: blocks_multiply_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [456, 536.0]
+    rotation: 0
+    state: enabled
+- name: blocks_multiply_xx_1
+  id: blocks_multiply_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [456, 456.0]
     rotation: 0
     state: enabled
 - name: digital_chunks_to_symbols_xx_0
@@ -243,7 +386,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [472, 156.0]
+    coordinate: [528, 152.0]
     rotation: 0
     state: enabled
 - name: gr_frequency_modulator_fc_0
@@ -293,7 +436,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [904, 336.0]
+    coordinate: [960, 368.0]
     rotation: 0
     state: enabled
 - name: gr_multiply_xx_1
@@ -311,76 +454,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1176, 608.0]
-    rotation: 0
-    state: enabled
-- name: gr_sig_source_x_0
-  id: analog_sig_source_x
-  parameters:
-    affinity: ''
-    alias: ''
-    amp: '1'
-    comment: ''
-    freq: 38e3
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    offset: '0'
-    phase: '0'
-    samp_rate: usrp_rate
-    showports: 'False'
-    type: float
-    waveform: analog.GR_SIN_WAVE
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [192, 568]
-    rotation: 0
-    state: enabled
-- name: gr_sig_source_x_0_0
-  id: analog_sig_source_x
-  parameters:
-    affinity: ''
-    alias: ''
-    amp: rds_gain
-    comment: ''
-    freq: 57e3
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    offset: '0'
-    phase: '0'
-    samp_rate: usrp_rate
-    showports: 'False'
-    type: float
-    waveform: analog.GR_SIN_WAVE
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [688, 124.0]
-    rotation: 0
-    state: enabled
-- name: gr_sig_source_x_0_1
-  id: analog_sig_source_x
-  parameters:
-    affinity: ''
-    alias: ''
-    amp: pilot_gain
-    comment: ''
-    freq: 19e3
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    offset: '0'
-    phase: '0'
-    samp_rate: usrp_rate
-    showports: 'False'
-    type: float
-    waveform: analog.GR_SIN_WAVE
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [192, 436.0]
+    coordinate: [1176, 552.0]
     rotation: 0
     state: enabled
 - name: gr_sub_xx_0
@@ -398,7 +472,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [672, 872.0]
+    coordinate: [672, 888.0]
     rotation: 0
     state: enabled
 - name: gr_unpack_k_bits_bb_0
@@ -451,7 +525,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [816, 692.0]
+    coordinate: [816, 684.0]
     rotation: 0
     state: enabled
 - name: low_pass_filter_0_0_0
@@ -475,7 +549,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [816, 836.0]
+    coordinate: [816, 844.0]
     rotation: 0
     state: enabled
 - name: network_socket_pdu_0
@@ -495,7 +569,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [32, 140.0]
+    coordinate: [40, 136.0]
     rotation: 0
     state: enabled
 - name: osmosdr_sink_0
@@ -837,7 +911,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1264, 888.0]
+    coordinate: [1288, 912.0]
     rotation: 0
     state: enabled
 - name: rational_resampler_xxx_0
@@ -857,7 +931,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [424, 700.0]
+    coordinate: [424, 696.0]
     rotation: 0
     state: enabled
 - name: rational_resampler_xxx_0_0
@@ -923,7 +997,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [208, 84.0]
+    coordinate: [264, 76.0]
     rotation: 0
     state: true
 - name: root_raised_cosine_filter_0
@@ -946,7 +1020,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [664, 324.0]
+    coordinate: [664, 320.0]
     rotation: 0
     state: enabled
 - name: uhd_usrp_sink
@@ -1230,8 +1304,20 @@ blocks:
 connections:
 - [analog_fm_preemph_0, '0', rational_resampler_xxx_0, '0']
 - [analog_fm_preemph_0_0, '0', rational_resampler_xxx_0_0, '0']
+- [analog_sig_source_x_0_1, '0', blocks_complex_to_imag_0, '0']
+- [analog_sig_source_x_0_1, '0', blocks_multiply_xx_0, '0']
+- [analog_sig_source_x_0_1, '0', blocks_multiply_xx_0, '1']
+- [analog_sig_source_x_0_1, '0', blocks_multiply_xx_1, '0']
 - [audio_source_0, '0', analog_fm_preemph_0, '0']
 - [audio_source_0, '1', analog_fm_preemph_0_0, '0']
+- [blocks_complex_to_imag_0, '0', blocks_multiply_const_vxx_0, '0']
+- [blocks_complex_to_imag_0_0, '0', gr_multiply_xx_1, '0']
+- [blocks_complex_to_imag_0_0_0, '0', blocks_multiply_const_vxx_1, '0']
+- [blocks_multiply_const_vxx_0, '0', gr_add_xx_1, '1']
+- [blocks_multiply_const_vxx_1, '0', gr_multiply_xx_0, '1']
+- [blocks_multiply_xx_0, '0', blocks_complex_to_imag_0_0, '0']
+- [blocks_multiply_xx_0, '0', blocks_multiply_xx_1, '1']
+- [blocks_multiply_xx_1, '0', blocks_complex_to_imag_0_0_0, '0']
 - [digital_chunks_to_symbols_xx_0, '0', root_raised_cosine_filter_0, '0']
 - [gr_add_xx_0, '0', low_pass_filter_0_0, '0']
 - [gr_add_xx_1, '0', gr_frequency_modulator_fc_0, '0']
@@ -1241,9 +1327,6 @@ connections:
 - [gr_map_bb_1, '0', gr_unpack_k_bits_bb_0, '0']
 - [gr_multiply_xx_0, '0', gr_add_xx_1, '0']
 - [gr_multiply_xx_1, '0', gr_add_xx_1, '2']
-- [gr_sig_source_x_0, '0', gr_multiply_xx_1, '0']
-- [gr_sig_source_x_0_0, '0', gr_multiply_xx_0, '0']
-- [gr_sig_source_x_0_1, '0', gr_add_xx_1, '1']
 - [gr_sub_xx_0, '0', low_pass_filter_0_0_0, '0']
 - [gr_unpack_k_bits_bb_0, '0', digital_chunks_to_symbols_xx_0, '0']
 - [low_pass_filter_0_0, '0', gr_add_xx_1, '3']
@@ -1256,8 +1339,8 @@ connections:
 - [rational_resampler_xxx_1, '0', osmosdr_sink_0, '0']
 - [rational_resampler_xxx_1, '0', uhd_usrp_sink, '0']
 - [rds_encoder_0, '0', gr_diff_encoder_bb_0, '0']
-- [root_raised_cosine_filter_0, '0', gr_multiply_xx_0, '1']
+- [root_raised_cosine_filter_0, '0', gr_multiply_xx_0, '0']
 
 metadata:
   file_format: 1
-  grc_version: 3.10.6.0
+  grc_version: 3.10.11.0


### PR DESCRIPTION
According to ITU-R BS.450-4, the phase of the 38 kHz stereo subcarrier must be locked relative to the phase of the 19 kHz pilot signal. Likewise, the RDS standards require that the phase of the 57 kHz RDS subcarrier must be locked relative to the phase of the 19 kHz pilot signal in stereo broadcasts.

In gr-rds, the pilot signal, stereo subcarrier, and RDS subcarrier are generated by three independent Signal Source blocks. Each block maintains its own phase accumulator, which is subject to rounding error. As a result, there is no guarantee that independent Signal Source blocks will maintain phase coherence.

By chance, the pilot signal and stereo subcarrier generated by gr-rds do remain locked in phase, because their frequencies happen to divide evenly into `usrp_rate` (380 kHz). But the frequency of the RDS subcarrier does not divide evenly into `usrp_rate`, and it does in fact drift relative to the pilot signal.

To ensure that the required phase relationships are maintained, the stereo and RDS subcarriers should be derived from the pilot signal. I updated the `rds_tx.grc` flow graph accordingly, and the new piece is shown in the red box below:

![rds_tx_box](https://github.com/user-attachments/assets/4ee4a61c-e351-47b8-9e13-4365862cdf96)

I verified that the phase relationship between the pilot signal and stereo subcarrier is correct according to the specification, and that the left and right channels are correctly modulated by a receiver (Sangean HDT-20).