### PR TITLE
Increase channel filter bandwidth

### DIFF
--- a/examples/rds_rx.grc
+++ b/examples/rds_rx.grc
@@ -37,7 +37,7 @@ blocks:
   id: variable
   parameters:
     comment: ''
-    value: '8'
+    value: '6'
   states:
     bus_sink: false
     bus_source: false
@@ -164,7 +164,7 @@ blocks:
   id: variable
   parameters:
     comment: ''
-    value: '2000000'
+    value: '1920000'
   states:
     bus_sink: false
     bus_source: false
@@ -593,7 +593,7 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: samp_rate
-    taps: firdes.low_pass(1, samp_rate, 100000, 20000)
+    taps: firdes.low_pass(1, samp_rate, 135000, 20000)
     type: ccc
   states:
     bus_sink: false
@@ -1754,4 +1754,4 @@ connections:
 
 metadata:
   file_format: 1
-  grc_version: 3.10.6.0
+  grc_version: 3.10.11.0


### PR DESCRIPTION
The bandwidth of an FM broadcast signal is approximately 270 kHz (https://en.wikipedia.org/wiki/FM_broadcasting#Bandwidth), but gr-rds uses a 200 kHz channel filter. Because the channel filter is too narrow, the baseband signal is distorted, which causes the audio signals to bleed into the RDS signal, reducing its SNR.

To solve the problem, I increased the channel filter bandwidth to 270 kHz. To accommodate the higher bandwidth, I also increased the intermediate sample rate from 250 ksps to 320 ksps, by changing the RF sample rate to 1.92 Msps and the decimation factor to 6.

Using a Frequency Sink, I verified that this change reduces the noise floor in the vicinity of the RDS signal by about 4 dB.