### PR TITLE
Reset the RDS parser when the frequency is changed

### DIFF
--- a/examples/rds_rx.grc
+++ b/examples/rds_rx.grc
@@ -912,7 +912,7 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     pty_locale: '0'
-    reset: '0'
+    reset: freq
   states:
     bus_sink: false
     bus_source: false

--- a/grc/rds_parser.block.yml
+++ b/grc/rds_parser.block.yml
@@ -42,6 +42,6 @@ templates:
     imports: import rds
     make: rds.parser(${log}, ${debug}, ${pty_locale})
     callbacks:
-    - reset(${reset})
+    - 'reset() # ${reset}'
 
 file_format: 1


### PR DESCRIPTION
When tuning from one station to the next, the displayed station name and radiotext will often be a mixture of data from the old & new frequencies. To solve this problem, we can call the RDS Parser's `reset()` method when the frequency is changed.