### PR TITLE
Reduce latency and CPU utilization

### DIFF
--- a/examples/rds_tx.grc
+++ b/examples/rds_tx.grc
@@ -324,7 +324,7 @@ blocks:
     comment: ''
     dimension: '1'
     in_type: byte
-    maxoutbuf: '0'
+    maxoutbuf: outbuffer
     minoutbuf: '0'
     num_ports: '1'
     out_type: float
@@ -360,7 +360,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: outbuffer
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_inputs: '4'
     type: float
@@ -395,7 +395,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: outbuffer
+    maxoutbuf: '0'
     minoutbuf: '0'
     sensitivity: 2*math.pi*fm_max_dev/usrp_rate
   states:
@@ -427,7 +427,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: outbuffer
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_inputs: '2'
     type: float
@@ -981,7 +981,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: '0'
+    maxoutbuf: outbuffer
     minoutbuf: '0'
     ms: 'True'
     pi_country_code: '13'


### PR DESCRIPTION
To control RDS latency, many blocks in rds_tx.grc have a maximum output buffer size (Maxoutbuf) specified. As noted in https://github.com/bastibl/gr-rds/issues/83#issuecomment-2447309950, this causes excessively high CPU utilization. This stems almost entirely from the high-sample-rate blocks (Multiply, Add, Frequency Mod) which contribute a negligible amount to the overall RDS latency. Removing the Maxoutbuf setting for these blocks reduces CPU utilization by about 65% without any noticeable effect on latency.

Also, two low-sample-rate blocks (RDS Encoder, Chunks to Symbols) do not specify a maximum output buffer size. Adding the setting to the RDS Encoder block reduces RDS latency from 72 seconds to 20. I've added the setting to the Chunks to Symbols block as well, but unfortunately it has no effect at the moment due to a bug in GNU Radio: https://github.com/gnuradio/gnuradio/issues/7534. If that bug is fixed, then another 7 seconds of latency could be removed.

As noted in https://github.com/bastibl/gr-rds/issues/83#issuecomment-2448942441, a better way to control latency would be to use the approach taken by gr-latency_manager: have the RDS Encoder block generate stream tags, and limit its output until those tags are seen downstream. That's a bigger change, so I thought it would make sense to do a quick fix to the Maxoutbuf settings first, which already gives a substantial improvement.