### PR TITLE
Remove references to offset word E

### DIFF
--- a/lib/decoder_impl.cc
+++ b/lib/decoder_impl.cc
@@ -84,7 +84,7 @@ unsigned int decoder_impl::calc_syndrome(unsigned long message,
 
 void decoder_impl::decode_group(unsigned int *group) {
 	// raw data bytes, as received from RDS.
-	// 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD/EEEE (in US)
+	// 8 info bytes, followed by 4 RDS offset chars: ABCD/ABcD
 	unsigned char bytes[12];
 
 	// RDS information words

--- a/lib/decoder_impl.h
+++ b/lib/decoder_impl.h
@@ -46,7 +46,7 @@ private:
 	unsigned int   blocks_counter;
 	unsigned int   group_good_blocks_counter;
 	unsigned int   group[4];
-	unsigned char  offset_chars[4];  // [ABCcDEx] (x=error)
+	unsigned char  offset_chars[4];  // [ABCcDx] (x=error)
 	bool           log;
 	bool           debug;
 	bool           presync;

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -577,7 +577,7 @@ void parser_impl::parse(pmt::pmt_t pdu) {
 	group[2] = bytes[5] | (((unsigned int)(bytes[4])) << 8U);
 	group[3] = bytes[7] | (((unsigned int)(bytes[6])) << 8U);
 
-	// TODO: verify offset chars are one of: "ABCD", "ABcD", "EEEE" (in US)
+	// TODO: verify offset chars are one of: "ABCD", "ABcD"
 
 	unsigned int group_type = (unsigned int)((group[1] >> 12) & 0xf);
 	bool ab = (group[1] >> 11 ) & 0x1;


### PR DESCRIPTION
gr-rds mentions offset word E in a few places, but does not actually implement it.

IEC 62106-1:2018 states:

> In previous editions of IEC 62106 the offset word E (binary value = 0) was used in the USA when RDS and MMBS (Modified Mobile Search paging) were implemented. This service has been discontinued and therefore there is no longer a need for new receivers to interpret offset word E.

Thus I think it's safe to remove references to offset word E.