### PR TITLE
Parser improvements

### DIFF
--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -24,6 +24,7 @@
 #include <gnuradio/io_signature.h>
 #include <math.h>
 #include <boost/locale.hpp>
+#include <algorithm>
 #include <cstring>
 #include <iomanip>
 #include <limits>
@@ -57,6 +58,7 @@ void parser_impl::reset() {
 
 	radiotext_segment_flags            = 0;
 	program_service_name_segment_flags = 0;
+	af_pairs.clear();
 
 	radiotext_AB_flag              = 0;
 	traffic_program                = false;
@@ -150,36 +152,12 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 	flagstring[4] = artificial_head        ? '1' : '0';
 	flagstring[5] = compressed             ? '1' : '0';
 	flagstring[6] = dynamic_pty            ? '1' : '0';
-	static std::string af_string;
 
 	if(!B) { // type 0A
-		af_code_1 = int(group[2] >> 8) & 0xff;
-		af_code_2 = int(group[2])      & 0xff;
-		af_1 = decode_af(af_code_1);
-		af_2 = decode_af(af_code_2);
-
-		std::stringstream af_stringstream;
-		af_stringstream << std::fixed << std::setprecision(2);
-
-		if(af_1) {
-			if(af_1 > 80e3) {
-				af_stringstream << (af_1/1e3) << "MHz";
-			} else if((af_1<2e3)&&(af_1>100)) {
-				af_stringstream << int(af_1) << "kHz";
-			}
-		}
-		if(af_1 && af_2) {
-			af_stringstream << ", ";
-		}
-		if(af_2) {
-			if(af_2 > 80e3) {
-				af_stringstream << (af_2/1e3) << "MHz";
-			} else if((af_2<2e3)&&(af_2>100)) {
-				af_stringstream << int(af_2) << "kHz";
-			}
-		}
-		if(af_1 || af_2) {
-			af_string = af_stringstream.str();
+		// Check whether this is a new pair of AF codes
+		if (std::find(af_pairs.begin(), af_pairs.end(), group[2]) == af_pairs.end()) {
+			af_pairs.push_back(group[2]);
+			decode_af_pairs();
 		}
 	}
 
@@ -188,44 +166,129 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 		<< '-' << (traffic_announcement ? "TA" : "  ")
 		<< '-' << (music_speech ? "Music" : "Speech")
 		<< '-' << (mono_stereo ? "STEREO" : "MONO")
-		<< " - AF:" << af_string << std::endl;
+		<< std::endl;
 
 	send_message(3, flagstring);
-	send_message(6, af_string);
 }
 
-double parser_impl::decode_af(unsigned int af_code) {
-	static unsigned int number_of_freqs = 0;
-	static bool vhf_or_lfmf             = 0; // 0 = vhf, 1 = lf/mf
-	double alt_frequency                = 0; // in kHz
+void parser_impl::decode_af_pairs() {
+	// Search for the first row, which indicates the number of frequencies
+	int first_row = -1;
+	int number_of_freqs = -1;
+	int freqs_seen = 0;
+	std::vector<int> freqs;
 
-	if((af_code == 0) ||                              // not to be used
-		( af_code == 205) ||                      // filler code
-		((af_code >= 206) && (af_code <= 223)) || // not assigned
-		( af_code == 224) ||                      // No AF exists
-		( af_code >= 251)) {                      // not assigned
-			number_of_freqs = 0;
-			alt_frequency   = 0;
-	}
-	if((af_code >= 225) && (af_code <= 249)) {        // VHF frequencies follow
-		number_of_freqs = af_code - 224;
-		alt_frequency   = 0;
-		vhf_or_lfmf     = 1;
-	}
-	if(af_code == 250) {                              // an LF/MF frequency follows
-		number_of_freqs = 1;
-		alt_frequency   = 0;
-		vhf_or_lfmf     = 0;
+	for (int i = 0; i < af_pairs.size(); i++) {
+		unsigned int af_1 = (af_pairs[i] >> 8);
+
+		if ((af_1 >= 224) && (af_1 <= 249)) {
+			first_row = i;
+			number_of_freqs = af_1 - 224;
+			break;
+		}
 	}
 
-	if((af_code > 0) && (af_code < 205) && vhf_or_lfmf)
-		alt_frequency = 100.0 * (af_code + 875);          // VHF (87.6-107.9MHz)
-	else if((af_code > 0) && (af_code < 16) && !vhf_or_lfmf)
-		alt_frequency = 153.0 + (af_code - 1) * 9;        // LF (153-279kHz)
-	else if((af_code > 15) && (af_code < 136) && !vhf_or_lfmf)
-		alt_frequency = 531.0 + (af_code - 16) * 9 + 531; // MF (531-1602kHz)
+	if (number_of_freqs == 0) {
+		return;
+	}
 
-	return alt_frequency;
+	if (first_row >= 0) {
+		unsigned int special_af = 0;
+		for (int i = first_row; i < first_row + af_pairs.size(); i++) {
+			unsigned int af_1 = (af_pairs[i % af_pairs.size()] >> 8);
+			unsigned int af_2 = (af_pairs[i % af_pairs.size()] & 0xff);
+
+			if (i == first_row) {
+				int freq = decode_af(af_2, false);
+				if (freq >= 0) {
+					freqs.push_back(freq);
+					freqs_seen++;
+					special_af = af_2;
+				}
+			} else if (af_1 == 250) {
+				// One LF/MF frequency follows
+				int freq = decode_af(af_2, true);
+				if (freq >= 0) {
+					freqs.push_back(freq);
+					freqs_seen++;
+				}
+			} else {
+				if ((af_1 == special_af) || (af_2 == special_af)) {
+					// AF method B
+					bool regional = (af_2 < af_1);
+
+					unsigned int new_af = (af_1 == special_af) ? af_2 : af_1;
+					int freq = decode_af(new_af, false);
+					if (freq >= 0) {
+						freqs.push_back(regional ? -freq : freq); // Negative indicates regional frequency
+						freqs_seen += 2;
+					}
+				} else {
+					int freq = decode_af(af_1, false);
+					if (freq >= 0) {
+						freqs.push_back(freq);
+						freqs_seen++;
+					}
+					freq = decode_af(af_2, false);
+					if (freq >= 0) {
+						freqs.push_back(freq);
+						freqs_seen++;
+					}
+				}
+			}
+		}
+
+		// Check whether we have the whole frequency list
+		if (freqs_seen == number_of_freqs) {
+			std::stringstream af_stringstream;
+			af_stringstream << std::fixed << std::setprecision(1);
+
+			bool first = true;
+			for (int freq : freqs) {
+				bool regional = false;
+				if (freq < 0) {
+					freq = -freq;
+					regional = true;
+				}
+
+				if (first) {
+					first = false;
+				} else {
+					af_stringstream << ", ";
+				}
+
+				if (freq > 10000) {
+					af_stringstream << (freq / 1000.0) << " MHz";
+				} else {
+					af_stringstream << freq << " kHz";
+				}
+
+				if (regional) {
+					af_stringstream << " (regional)";
+				}
+			}
+
+			send_message(6, af_stringstream.str());
+			lout << "AF: " << af_stringstream.str() << std::endl;
+		}
+	}
+
+}
+
+int parser_impl::decode_af(unsigned int af_code, bool lf_mf) {
+	if (lf_mf) {
+		if ((af_code >= 1) && (af_code <= 15)) {
+			return 153 + (af_code - 1) * 9; // LF (153-279kHz)
+		} else if ((af_code >= 16) && (af_code < 135)) {
+			return 531 + (af_code - 16) * 9; // MF (531-1602kHz)
+		}
+	} else {
+		if ((af_code >= 1) && (af_code <= 204)) {
+			return 87600 + (af_code - 1) * 100; // VHF (87.6-107.9MHz)
+		}
+	}
+
+	return -1; // Invalid input
 }
 
 void parser_impl::decode_type1(unsigned int *group, bool B){

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <boost/locale.hpp>
 #include <iomanip>
+#include <limits>
 
 using namespace gr::rds;
 
@@ -60,6 +61,7 @@ void parser_impl::reset() {
 	traffic_program                = false;
 	traffic_announcement           = false;
 	music_speech                   = false;
+	program_identification         = UINT_MAX;
 	program_type                   = 0;
 	pi_country_identification      = 0;
 	pi_area_coverage               = 0;
@@ -585,6 +587,9 @@ void parser_impl::parse(pmt::pmt_t pdu) {
 	lout << std::setfill('0') << std::setw(2) << group_type << (ab ? 'B' : 'A') << " ";
 	lout << "(" << rds_group_acronyms[group_type] << ")";
 
+	if (program_identification != group[0]) {
+		reset();
+	}
 	program_identification = group[0];     // "PI"
 	program_type = (group[1] >> 5) & 0x1f; // "PTY"
 	int pi_country_identification = (program_identification >> 12) & 0xf;

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -24,6 +24,7 @@
 #include <gnuradio/io_signature.h>
 #include <math.h>
 #include <boost/locale.hpp>
+#include <cstring>
 #include <iomanip>
 #include <limits>
 
@@ -54,7 +55,7 @@ parser_impl::~parser_impl() {
 void parser_impl::reset() {
 	gr::thread::scoped_lock lock(d_mutex);
 
-	memset(radiotext, ' ', sizeof(radiotext));
+	radiotext_segment_flags            = 0;
 	program_service_name_segment_flags = 0;
 
 	radiotext_AB_flag              = 0;
@@ -287,12 +288,12 @@ void parser_impl::decode_type2(unsigned int *group, bool B){
 
 	// when the A/B flag is toggled, flush your current radiotext
 	if(radiotext_AB_flag != ((group[1] >> 4) & 0x01)) {
-		std::memset(radiotext, ' ', sizeof(radiotext));
+		radiotext_segment_flags = 0;
 	}
 	radiotext_AB_flag = (group[1] >> 4) & 0x01;
 
 	if(!B) {
-		radiotext[text_segment_address_code *4     ] = (group[2] >> 8) & 0xff;
+		radiotext[text_segment_address_code * 4    ] = (group[2] >> 8) & 0xff;
 		radiotext[text_segment_address_code * 4 + 1] =  group[2]       & 0xff;
 		radiotext[text_segment_address_code * 4 + 2] = (group[3] >> 8) & 0xff;
 		radiotext[text_segment_address_code * 4 + 3] =  group[3]       & 0xff;
@@ -300,10 +301,35 @@ void parser_impl::decode_type2(unsigned int *group, bool B){
 		radiotext[text_segment_address_code * 2    ] = (group[3] >> 8) & 0xff;
 		radiotext[text_segment_address_code * 2 + 1] =  group[3]       & 0xff;
 	}
-	lout << "Radio Text " << (radiotext_AB_flag ? 'B' : 'A')
-		<< ": " << std::string(radiotext, sizeof(radiotext))
-		<< std::endl;
-	send_message(4,std::string(radiotext, sizeof(radiotext)));
+	radiotext_segment_flags |= (1 << text_segment_address_code);
+
+	// Count how many valid segments we have.
+	int valid_segments = 0;
+	for (int segment_address = 0; segment_address < 16; segment_address++) {
+		if (radiotext_segment_flags & (1 << segment_address)) {
+			valid_segments++;
+		} else {
+			break;
+		}
+	}
+
+	// Check for the end of the radiotext, indicated by a carriage return.
+	int segment_width = (B ? 2 : 4);
+	char *tail = (char *) std::memchr(radiotext, '\r', valid_segments * segment_width);
+
+	// Special case: radiotext that take up the entire buffer is not
+	// required to have a trailing carriage return.
+	if (!tail && (valid_segments == 16)) {
+		tail = radiotext + (16 * segment_width);
+	}
+
+	// If the radiotext is complete, report it.
+	if (tail) {
+		lout << "Radio Text " << (radiotext_AB_flag ? 'B' : 'A')
+			<< ": " << std::string(radiotext, tail - radiotext)
+			<< std::endl;
+		send_message(4, std::string(radiotext, tail - radiotext));
+	}
 }
 
 void parser_impl::decode_type3(unsigned int *group, bool B){

--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -55,7 +55,7 @@ void parser_impl::reset() {
 	gr::thread::scoped_lock lock(d_mutex);
 
 	memset(radiotext, ' ', sizeof(radiotext));
-	memset(program_service_name, '.', sizeof(program_service_name));
+	program_service_name_segment_flags = 0;
 
 	radiotext_AB_flag              = 0;
 	traffic_program                = false;
@@ -101,8 +101,29 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 	bool decoder_control_bit      = (group[1] >> 2) & 0x01; // "DI"
 	unsigned char segment_address =  group[1] & 0x03;       // "DI segment"
 
-	program_service_name[segment_address * 2]     = (group[3] >> 8) & 0xff;
-	program_service_name[segment_address * 2 + 1] =  group[3]       & 0xff;
+	char ps_1 = (group[3] >> 8) & 0xff;
+	char ps_2 =  group[3]       & 0xff;
+
+	if (program_service_name_segment_flags & (1 << segment_address)) {
+		// Already received this segment. Check whether the characters have changed.
+		if ((program_service_name[segment_address * 2] != ps_1) 
+				|| (program_service_name[segment_address * 2 + 1] != ps_2)) {
+			// The characters changed, so reset and start from scratch.
+			program_service_name[segment_address * 2]     = ps_1;
+			program_service_name[segment_address * 2 + 1] = ps_2;
+			program_service_name_segment_flags = (1 << segment_address);
+		}
+	} else {
+		// New segment received. Store it.
+		program_service_name[segment_address * 2]     = ps_1;
+		program_service_name[segment_address * 2 + 1] = ps_2;
+		program_service_name_segment_flags |= (1 << segment_address);
+
+		// If we now have all segments, report the full program service name.
+		if (program_service_name_segment_flags == 0xf) {
+			send_message(1, std::string(program_service_name, 8));
+		}
+	}
 
 	/* see page 41, table 9 of the standard */
 	switch (segment_address) {
@@ -168,7 +189,6 @@ void parser_impl::decode_type0(unsigned int *group, bool B) {
 		<< '-' << (mono_stereo ? "STEREO" : "MONO")
 		<< " - AF:" << af_string << std::endl;
 
-	send_message(1, std::string(program_service_name, 8));
 	send_message(3, flagstring);
 	send_message(6, af_string);
 }

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -60,7 +60,8 @@ private:
 	unsigned char  pi_area_coverage;
 	unsigned char  pi_program_reference_number;
 	char           radiotext[65];
-	char           program_service_name[9];
+	char           program_service_name[8];
+	unsigned int   program_service_name_segment_flags;
 	bool           radiotext_AB_flag;
 	bool           traffic_program;
 	bool           traffic_announcement;

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -59,7 +59,8 @@ private:
 	unsigned char  pi_country_identification;
 	unsigned char  pi_area_coverage;
 	unsigned char  pi_program_reference_number;
-	char           radiotext[65];
+	char           radiotext[64];
+	unsigned int   radiotext_segment_flags;
 	char           program_service_name[8];
 	unsigned int   program_service_name_segment_flags;
 	bool           radiotext_AB_flag;

--- a/lib/parser_impl.h
+++ b/lib/parser_impl.h
@@ -34,7 +34,8 @@ private:
 	void reset();
 	void send_message(long, std::string);
 	void parse(pmt::pmt_t pdu);
-	double decode_af(unsigned int);
+	void decode_af_pairs();
+	int decode_af(unsigned int af_code, bool lf_mf);
 	void decode_optional_content(int, unsigned long int *);
 
 	void decode_type0( unsigned int* group, bool B);
@@ -64,6 +65,7 @@ private:
 	char           program_service_name[8];
 	unsigned int   program_service_name_segment_flags;
 	bool           radiotext_AB_flag;
+	std::vector<unsigned int> af_pairs;
 	bool           traffic_program;
 	bool           traffic_announcement;
 	bool           music_speech;


### PR DESCRIPTION
Here I have made some improvements to the RDS Parser block, which should make the output nicer to work with:

1. Reset the parser if a new PI code is seen. This prevents data from different stations from being mixed together.
2. Only report the Program Service name after it has fully loaded. At present, gr-rds reports partially-received PS data with ".." replacing the missing pieces, and shows a mixture of old & new PS data during changes. This behaviour is particularly problematic in North America, where the RDS standard allows PS data to be updated dynamically (and most broadcasters do this).
3. Only report radiotext after it has fully loaded, and return only the valid portion of the buffer. At present, gr-rds returns the entire radiotext buffer every time it is touched. The buffer includes the string terminator (carriage return) as well as subsequent filler data (typically null bytes) which corrupts the display in the RDS Panel block. The current behaviour also has the effect of clearing the radiotext immediately when a new radiotext message begins, and this can make it very difficult to read radiotext messages that change frequently.
4. ~~Clear the alternate frequency string before processing each type 0 group. At present, gr-rds stores this in a static variable which is never cleared. This causes alternate frequencies from one station to appear when receiving other stations that do not specify alternate frequencies.~~

**Update**: I replaced part 4 with a more complete implementation of alternate frequency parsing. At present, gr-rds processes fragments of the alternate frequency list one at a time, which causes the RDS panel to rapidly cycle between alternate frequencies whenever a station defines more than one. In addition, it does not handle "AF method B", which allows the broadcaster to distinguish between frequencies that are the same program vs. those that are regional variants. (This method is used by our national broadcaster here in Canada.) I modified the code to collect fragments of the alternate frequency list until the entire list is available, parse it (using method A or B, as appropriate), and display it as a single list. Here's what it looks like:

![Screenshot from 2024-11-02 22-48-49](https://github.com/user-attachments/assets/56de1c17-ef73-4bf7-bdb9-346bd82e7fad)