### PR TITLE
Fix parsing of "diversion advice" bit

### DIFF
--- a/lib/parser_impl.cc
+++ b/lib/parser_impl.cc
@@ -496,7 +496,7 @@ void parser_impl::decode_type8(unsigned int *group, bool B){
 	}
 	bool T = (group[1] >> 4) & 0x1; // 0 = user message, 1 = tuning info
 	bool F = (group[1] >> 3) & 0x1; // 0 = multi-group, 1 = single-group
-	bool D = (group[2] > 15) & 0x1; // 1 = diversion recommended
+	bool D = (group[2] >> 15) & 0x1; // 1 = diversion recommended
 
 	if(T) { // tuning info
 		lout << "#tuning info# ";
@@ -514,8 +514,11 @@ void parser_impl::decode_type8(unsigned int *group, bool B){
 		unsigned int extent   = (group[2] >> 11) & 0x7;   // number of segments affected
 		unsigned int event    =  group[2]        & 0x7ff; // event code, defined in ISO 14819-2
 		unsigned int location =  group[3];                // location code, defined in ISO 14819-3
-		lout << "#user msg# " << (D ? "diversion recommended, " : "");
+		lout << "#user msg# ";
 		if(F) {
+			if (D) {
+				lout << "diversion recommended, ";
+			}
 			lout << "single-grp, duration:" << tmc_duration[dp_ci][0];
 		} else {
 			lout << "multi-grp, continuity index:" << dp_ci;


### PR DESCRIPTION
While reviewing #89, I noticed that multi-group messages are not fully processed. This happens because the code that extracts the "D" bit is incorrect. (In single-group messages, this bit indicates "diversion advice", whereas in multi-group messages it indicates whether this message is the first in the group.)

Additionally, the log output interprets this bit as diversion advice regardless of whether the message is single-group or multi-group; the standard states "The diversion bit, included in single-group messages only [...]".

Here I have fixed both issues.

Before:
```
08A (TMC) - PI:33EB - PTY:Travel (country:AD/SM/PL/TR/__, area:Supra-regional, program:235)
#user msg# diversion recommended, multi-grp, continuity index:1, extent:-2 segments, event520:(Q) lane(s) blocked, location:9614
08A (TMC) - PI:33EB - PTY:Travel (country:AD/SM/PL/TR/__, area:Supra-regional, program:235)
#user msg# diversion recommended, multi-grp, continuity index:1, extent:-2 segments, event463:blocked ahead. Delays (Q), location:49312
```

After:
```
8A (TMC) - PI:33EB - PTY:Travel (country:AD/SM/PL/TR/__, area:Supra-regional, program:235)
#user msg# multi-grp, continuity index:1, extent:-2 segments, event520:(Q) lane(s) blocked, location:9614
08A (TMC) - PI:33EB - PTY:Travel (country:AD/SM/PL/TR/__, area:Supra-regional, program:235)
#user msg# multi-grp, continuity index:1, second group, gsi:0, free format: 2511 49312
TMC optional content (Duration):4
TMC optional content (Separator):0
TMC optional content (Explicit start time):133
TMC optional content (Duration):0
```