### PR TITLE
Allow setting a raw PI code in the encoder

### DIFF
--- a/grc/rds_encoder.block.yml
+++ b/grc/rds_encoder.block.yml
@@ -69,8 +69,9 @@ parameters:
     option_labels: [Local, International, National, Supra-regional, Regional 1, Regional
             2, Regional 3, Regional 4, Regional 5, Regional 6, Regional 7, Regional
             8, Regional 9, Regional 10, Regional 11, Regional 12]
+    hide: ${ ('all' if str(pi_country_code) == '0' else 'none') }
 -   id: pi_reference_number
-    label: PI Program Reference Number
+    label: ${ ('PI Code' if str(pi_country_code) == '0' else 'PI Program Reference Number') }
     dtype: int
     default: '147'
 -   id: radiotext

--- a/grc/rds_encoder.block.yml
+++ b/grc/rds_encoder.block.yml
@@ -57,9 +57,9 @@ parameters:
     label: PI Country Code
     dtype: int
     default: '13'
-    options: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13',
+    options: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13',
         '15']
-    option_labels: [DE, DZ, AD, IL, IT, BE, RU, PS, AL, AT, HU, MT, DE, EG]
+    option_labels: [Other, DE, DZ, AD, IL, IT, BE, RU, PS, AL, AT, HU, MT, DE, EG]
 -   id: pi_coverage_area
     label: PI Coverage Area
     dtype: int

--- a/lib/encoder_impl.cc
+++ b/lib/encoder_impl.cc
@@ -52,9 +52,14 @@ encoder_impl::encoder_impl (unsigned char pty_locale, int pty, bool ms,
 	d_current_buffer     = 0;
 	d_buffer_bit_counter = 0;
 
-	PI                   = (pi_country_code & 0xF) << 12 |
-	                       (pi_coverage_area & 0xF) << 8 |
-	                       (pi_reference_number);
+	if (pi_country_code == 0) {
+		PI                 = pi_reference_number;
+	} else {
+		PI                 = (pi_country_code & 0xF) << 12 |
+		                     (pi_coverage_area & 0xF) << 8 |
+		                     (pi_reference_number);
+	}
+
 	PTY                  = pty;     // programm type (education)
 	TP                   = tp;      // traffic programm
 	TA                   = ta;      // traffic announcement


### PR DESCRIPTION
This adds an `Other` country code that will use the program reference number directly as PI.