### PR TITLE
Update MANIFEST to yaml format and install examples to discoverable dir

### DIFF
--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -61,8 +61,8 @@ test:
     # test that example flowgraphs compile
     {% set flowgraphs = ["rds_rx", "rds_tx"] %}
     {% for flowgraph in flowgraphs %}
-    - grcc $PREFIX/share/gr-{{ oot_name }}/examples/{{ flowgraph }}.grc  # [not win]
-    - grcc %PREFIX%\\Library\\share\\gr-{{ oot_name }}\\examples\\{{ flowgraph }}.grc  # [win]
+    - grcc $PREFIX/share/gnuradio/examples/{{ oot_name }}/{{ flowgraph }}.grc  # [not win]
+    - grcc %PREFIX%\\Library\\share\\gnuradio\\examples\\{{ oot_name }}\\{{ flowgraph }}.grc  # [win]
     {% endfor %}
 
     # verify that (some) headers get installed

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,3 +175,7 @@ endif(ENABLE_PYTHON)
 install(FILES cmake/Modules/rdsConfig.cmake
     DESTINATION ${CMAKE_MODULES_DIR}/rds
 )
+
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/rds)

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,24 @@
+title: The RDS OOT Module
+version: 1.0
+brief: FM RDS/TMC Transceiver
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - FM
+  - RDS
+  - TMC
+author:
+  - Bastian Bloessl <bloessl@ccs-labs.org>
+copyright_owner:
+  - Bastian Bloessl
+  - Free Software Foundation
+license: GPL-3.0-or-later
+gr_supported_version:
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+repo: https://github.com/bastibl/gr-rds.git
+website: https://github.com/bastibl/gr-rds
+icon: https://fosdem.org/2015/schedule/event/sdr_rds_tmc/sdr_rds_tmc-c26370b6d55400089388d96b7d18d1b1067e997c76e8d8f1b2c6f94862866a1f.png
+description: |-
+  An FM RDS/TMC Transceiver for GNU Radio.
+file_format: 1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,4 +8,4 @@
 install(
     FILES rds_rx.grc
           rds_tx.grc
-    DESTINATION ${GR_PKG_DATA_DIR}/examples)
+    DESTINATION share/gnuradio/examples/rds)


### PR DESCRIPTION
This improves use with the Qt version of GRC, which has an example browser which looks in `share/gnuradio/examples/<OOT_NAME>` and an OOT browser which will eventually be able to read from installed manifest files.

See https://github.com/gnuradio/gnuradio/pull/7134, https://github.com/gnuradio/gnuradio/pull/7151, and https://github.com/gnuradio/gnuradio/pull/7245 for related changes to the upstream OOT template.

(Although I will note that I've just noticed that CGRAN still only looks for the old manifest format, so perhaps best to hold off on this for a little.)